### PR TITLE
javaprocess.py: Capture STDERR properly

### DIFF
--- a/ocrd_cis/javaprocess.py
+++ b/ocrd_cis/javaprocess.py
@@ -104,12 +104,12 @@ class JavaProcess:
 
         cmd = self.get_cmd()
         self.log.info('command: %s', " ".join(cmd))
-        ret = subprocess.run(cmd)
+        ret = subprocess.run(cmd, stderr=subprocess.PIPE, check=False, universal_newlines=True)
         self.log.debug("%s: %i", " ".join(cmd), ret.returncode)
         if ret.returncode != 0:
             raise ValueError(
                 "cannot execute {}: {}\n{}"
-                .format(" ".join(cmd), ret.returncode, err.decode('utf-8')))
+                .format(" ".join(cmd), ret.returncode, ret.stderr))
 
     def log_stderr(self, err):
         for line in err.decode("utf-8").split("\n"):


### PR DESCRIPTION
Looks like a refactoring artifact? `err` wasn't defined.