### PR TITLE
recognize: make TextRegion/TextEquiv consistent with line results

### DIFF
--- a/ocrd_cis/ocropy/denoise.py
+++ b/ocrd_cis/ocropy/denoise.py
@@ -103,7 +103,7 @@ class OcropyDenoise(Processor):
                             line, region_image, region_xywh,
                             feature_selector='binarized')
                         self.process_segment(line, line_image, line_xywh, zoom,
-                                             input_file.pageId, region.id,
+                                             input_file.pageId,
                                              file_id + '_' + region.id + '_' + line.id)
             
             # update METS (add the PAGE file):

--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -182,6 +182,11 @@ class OcropyRecognize(Processor):
                 edits_, lengs_ = self.process_lines(textlines, maxlevel, region_image, region_coords)
                 edits += edits_
                 lengs += lengs_
+            # update region text by concatenation for consistency
+            region_unicode = u'\n'.join(line.get_TextEquiv()[0].Unicode
+                                        if line.get_TextEquiv()
+                                        else u'' for line in textlines)
+            region.set_TextEquiv([TextEquivType(Unicode=region_unicode)])
         if lengs > 0:
             LOG.info('CER: %.1f%%', 100.0 * edits / lengs)
 


### PR DESCRIPTION
(This is necessary to pass the PAGE validator's default consistency level.)