### PR TITLE
ocropy-recognize: initialize network at start of self.process, fix #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ env/*
 env-dir/*
 .envrc
 /venv*
+/build
+/dist


### PR DESCRIPTION
`__init__` is always executed but not all instantiations are for processing, e.g. dumping the ocrd-tool.json or help or version etc. Therefore it's better to do any setup that requires parameters and such in `process`.