### PR TITLE
ocrd-cis-post-correct.sh: -ALIGN group from joining input-file-grp

### DIFF
--- a/bashlib/ocrd-cis-post-correct.sh
+++ b/bashlib/ocrd-cis-post-correct.sh
@@ -57,7 +57,7 @@ for cmd in $(cat $PARAMETER | jq -r '.ocrSteps[] | @base64'); do
 	eval $cmd || exit 1
 	alignfgs="$alignfgs,$XML_OUTPUT_FILE_GRP"
 done
-alignfg="$XML_INPUT_FILE_GRP-ALIGN"
+alignfg="$(echo "$XML_OUTPUT_FILE_GRP"|sed 's|,|_|g')-ALIGN"
 ocrd-cis-debug ocrd-cis-align --mets $METS \
 			   --input-file-grp "$alignfgs" \
 			   --output-file-grp "$alignfg"


### PR DESCRIPTION
This should fix the "output file group already in METS" issue of #40 though the script still doesn't finish for me:


```sh
19:48:10.063 INFO ocrd.cis.bashlib - step: post-correction
+ ocrd-cis-debug java -Dfile.encoding=UTF-8 -Xmx3g -cp /home/kba/build/github.com/OCR-D/monorepo/ocrd_cis/ocrd_cis/data/ocrd-cis.jar de.lmu.cis.ocrd.cli.Main --log-level INFO -c post-correct --mets /tmp/test-ocrd-cis/1541_2/mets.xml --parameter /dev/fd/63 --input-file-grp ''                
+ case $LOG_LEVEL in
+ java -Dfile.encoding=UTF-8 -Xmx3g -cp /home/kba/build/github.com/OCR-D/monorepo/ocrd_cis/ocrd_cis/data/ocrd-cis.jar de.lmu.cis.ocrd.cli.Main --log-level INFO -c post-correct --mets /tmp/test-ocrd-cis/1541_2/mets.xml --parameter /dev/fd/63 --input-file-grp OCR-D-OCR-TESSEROCR-GT4HISTOCR_OCR-D-OCR-CALAMARI_GT4HIST-ALIGN --output-file-grp OCR-D-CORRECT
++ jq '.postCorrection.nOCR = "1" | .postCorrection' /tmp/test-ocrd-cis/1541_2/post-correct.json                                                 
++ jq '.postCorrection.nOCR = "1" | .postCorrection' /tmp/test-ocrd-cis/1541_2/post-correct.json                                                 
java.nio.file.NoSuchFileException: null/model.zip
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)                                                      
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)                                                       
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)                                                       
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)                                      
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:145)                                           
        at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)                                          
        at java.base/java.nio.file.Files.readAttributes(Files.java:1755)
        at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:951)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:216)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:148)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:162)
        at de.lmu.cis.ocrd.ml.ModelZIP.open(ModelZIP.java:24)
        at de.lmu.cis.ocrd.cli.PostCorrectionCommand.execute(PostCorrectionCommand.java:38)                                                      
        at de.lmu.cis.ocrd.cli.Main.run(Main.java:36)
        at de.lmu.cis.ocrd.cli.Main.main(Main.java:10)
+ rm -rfv /tmp/tmp.cYQ1cNf5Na
removed directory '/tmp/tmp.cYQ1cNf5Na/training'
removed directory '/tmp/tmp.cYQ1cNf5Na'
```
 