### PR TITLE
ocropy-deskew: append 'deskewed' feature to comments even if image wa…

### DIFF
--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -132,7 +132,6 @@ class OcropyDeskew(Processor):
                      file_id, self.page_grp, out.local_filename)
 
     def _process_segment(self, segment, segment_image, segment_coords, segment_id, page_id, file_id):
-        features = segment_coords['features'] # features already applied to segment_image
         angle0 = segment_coords['angle'] # deskewing (w.r.t. top image) already applied to segment_image
         LOG.info("About to deskew %s", segment_id)
         angle = deskew(segment_image, maxskew=self.parameter['maxskew']) # additional angle to be applied
@@ -147,7 +146,6 @@ class OcropyDeskew(Processor):
                       segment_id, angle)
             segment_image = rotate_image(segment_image, angle,
                                          fill='background', transparency=True)
-            features += ',deskewed'
         # update METS (add the image file):
         file_path = self.workspace.save_image_file(
             segment_image,
@@ -156,4 +154,5 @@ class OcropyDeskew(Processor):
             file_grp=self.image_grp)
         # update PAGE (reference the image file):
         segment.add_AlternativeImage(AlternativeImageType(
-            filename=file_path, comments=features))
+            filename=file_path,
+            comments=segment_coords['features'] + ',deskewed'))


### PR DESCRIPTION
The current implementation of the `deskew` processor will only append the string ",deskewed" to the `comments` field of the `AlternativeImage` if the segment being processed was effectively rotated. That is, segments that are not skewed are not modified by the processor and therefore not marked as "deskewed".

Say we want to run a processor `p` that requires the input images to be deskewed (e.g. `ocrd-anybaseocr-testline`) and at least one of those images is not skewed from the beginning. If we run `ocrd-cis-ocropy-deskew` before in order to meet this condition, it  will not mark all images as "deskewed" and `p` will fail because the requirement was not met, breaking the workflow.

Appending the ",deskewed" string in all cases fixes this issue, and also seems reasonable for cases where nothing is changed since the segment was already "not skewed".