### PR TITLE
Ocropy segmentation, squared

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Arguments:
  * `--mets` path to METS file in the workspace
 
 ### ocrd-cis-ocropy-train
-The ocropy-train tool can be used to train LSTM models.
+The `ocropy-train` tool can be used to train LSTM models.
 It takes ground truth from the workspace and saves (image+text) snippets from the corresponding pages.
 Then a model is trained on all snippets for 1 million (or the given number of) randomized iterations from the parameter file.
 ```sh
@@ -122,8 +122,9 @@ ocrd-cis-ocropy-train \
 ```
 
 ### ocrd-cis-ocropy-clip
-The ocropy-clip tool can be used to remove intrusions of neighbouring segments in regions / lines of a workspace.
-It runs a (ad-hoc binarization and) connected component analysis on every text region / line of every PAGE in the input file group, as well as its overlapping neighbours, and for each binary object of conflict, determines whether it belongs to the neighbour, and can therefore be clipped to white. It references the resulting segment image files in the output PAGE (as AlternativeImage).
+The `ocropy-clip` tool can be used to remove intrusions of neighbouring segments in regions / lines of a page.
+It runs a connected component analysis on every text region / line of every PAGE in the input file group, as well as its overlapping neighbours, and for each binary object of conflict, determines whether it belongs to the neighbour, and can therefore be clipped to the background. It references the resulting segment image files in the output PAGE (as AlternativeImage).
+(Use this to suppress separators and neighbouring text.)
 ```sh
 ocrd-cis-ocropy-clip \
   --input-file-grp OCR-D-SEG-LINE \
@@ -133,8 +134,9 @@ ocrd-cis-ocropy-clip \
 ```
 
 ### ocrd-cis-ocropy-resegment
-The ocropy-resegment tool can be used to remove overlap between lines of a workspace.
-It runs a (ad-hoc binarization and) line segmentation on every text region of every PAGE in the input file group, and for each line already annotated, determines the label of largest extent within the original coordinates (polygon outline) in that line, and annotates the resulting coordinates in the output PAGE.
+The `ocropy-resegment` tool can be used to remove overlap between neighbouring lines of a page.
+It runs a line segmentation on every text region of every PAGE in the input file group, and for each line already annotated, determines the label of largest extent within the original coordinates (polygon outline) in that line, and annotates the resulting coordinates in the output PAGE.
+(Use this to polygonalise text lines poorly segmented, e.g. via bounding boxes.)
 ```sh
 ocrd-cis-ocropy-resegment \
   --input-file-grp OCR-D-SEG-LINE \
@@ -144,8 +146,9 @@ ocrd-cis-ocropy-resegment \
 ```
 
 ### ocrd-cis-ocropy-segment
-The ocropy-segment tool can be used to segment regions into lines.
-It runs a (ad-hoc binarization and) line segmentation on every text region of every PAGE in the input file group, and adds a TextLine element with the resulting polygon outline to the annotation of the output PAGE.
+The `ocropy-segment` tool can be used to segment (pages or) regions of a page into lines.
+It runs a line segmentation on every (page or) text region of every PAGE in the input file group, and adds (text regions containing) TextLine elements with the resulting polygon outlines to the annotation of the output PAGE.
+(Does not detect tables or images.)
 ```sh
 ocrd-cis-ocropy-segment \
   --input-file-grp OCR-D-SEG-BLOCK \
@@ -155,8 +158,9 @@ ocrd-cis-ocropy-segment \
 ```
 
 ### ocrd-cis-ocropy-deskew
-The ocropy-deskew tool can be used to deskew pages / regions of a workspace.
-It runs the Ocropy thresholding and deskewing estimation on every segment of every PAGE in the input file group and annotates the orientation angle in the output PAGE.
+The `ocropy-deskew` tool can be used to deskew pages / regions of a page.
+It runs a projection profile-based skew estimation on every segment of every PAGE in the input file group and annotates the orientation angle in the output PAGE.
+(Does not include orientation detection.)
 ```sh
 ocrd-cis-ocropy-deskew \
   --input-file-grp OCR-D-SEG-LINE \
@@ -166,8 +170,8 @@ ocrd-cis-ocropy-deskew \
 ```
 
 ### ocrd-cis-ocropy-denoise
-The ocropy-denoise tool can be used to despeckle pages / regions / lines of a workspace.
-It runs the Ocropy "nlbin" denoising on every segment of every PAGE in the input file group and references the resulting segment image files in the output PAGE (as AlternativeImage).
+The `ocropy-denoise` tool can be used to despeckle pages / regions / lines of a page.
+It runs a connected component analysis and removes small components (black or white) on every segment of every PAGE in the input file group and references the resulting segment image files in the output PAGE (as AlternativeImage).
 ```sh
 ocrd-cis-ocropy-denoise \
   --input-file-grp OCR-D-SEG-LINE-DES \
@@ -177,8 +181,8 @@ ocrd-cis-ocropy-denoise \
 ```
 
 ### ocrd-cis-ocropy-binarize
-The ocropy-binarize tool can be used to binarize, denoise and deskew pages / regions / lines of a workspace.
-It runs the Ocropy "nlbin" adaptive thresholding, deskewing estimation and denoising on every segment of every PAGE in the input file group and references the resulting segment image files in the output PAGE (as AlternativeImage). (If a deskewing angle has already been annotated in a region, the tool respects that and rotates accordingly.) Images can also be produced grayscale-normalized.
+The `ocropy-binarize` tool can be used to binarize (and optionally denoise and deskew) pages / regions / lines of a page.
+It runs the "nlbin" adaptive whitelevel thresholding on every segment of every PAGE in the input file group and references the resulting segment image files in the output PAGE (as AlternativeImage). (If a deskewing angle has already been annotated in a region, the tool respects that and rotates accordingly.) Images can also be produced grayscale-normalized.
 ```sh
 ocrd-cis-ocropy-binarize \
   --input-file-grp OCR-D-SEG-LINE-DES \
@@ -188,8 +192,8 @@ ocrd-cis-ocropy-binarize \
 ```
 
 ### ocrd-cis-ocropy-dewarp
-The ocropy-dewarp tool can be used to dewarp text lines of a workspace.
-It runs the Ocropy baseline estimation and dewarping on every line in every text region of every PAGE in the input file group and references the resulting line image files in the output PAGE (as AlternativeImage).
+The `ocropy-dewarp` tool can be used to dewarp text lines of a page.
+It runs the baseline estimation and center normalizer algorithm on every line in every text region of every PAGE in the input file group and references the resulting line image files in the output PAGE (as AlternativeImage).
 ```sh
 ocrd-cis-ocropy-dewarp \
   --input-file-grp OCR-D-SEG-LINE-BIN \
@@ -199,8 +203,8 @@ ocrd-cis-ocropy-dewarp \
 ```
 
 ### ocrd-cis-ocropy-recognize
-The ocropy-recognize tool can be used to recognize lines / words / glyphs from pages of a workspace.
-It runs the Ocropy optical character recognition on every line in every text region of every PAGE in the input file group and adds the resulting text annotation in the output PAGE.
+The `ocropy-recognize` tool can be used to recognize the lines / words / glyphs of a page.
+It runs LSTM optical character recognition on every line in every text region of every PAGE in the input file group and adds the resulting text annotation in the output PAGE.
 ```sh
 ocrd-cis-ocropy-recognize \
   --input-file-grp OCR-D-SEG-LINE-DEW \
@@ -232,18 +236,19 @@ place them into: /usr/share/tesseract-ocr/4.00/tessdata
 
 A decent pipeline might look like this:
 
+0. page-level binarization
 1. page-level cropping
-2. page-level binarization
+2. (page-level binarization)
 3. page-level deskewing
-4. page-level dewarping
+4. (page-level dewarping)
 5. region segmentation
 6. region-level clipping
-7. region-level deskewing
+7. (region-level deskewing)
 8. line segmentation
-9. line-level clipping or resegmentation
+9. (line-level clipping or resegmentation)
 10. line-level dewarping
 11. line-level recognition
-12. line-level alignment
+12. (line-level alignment and post-correction)
 
 If GT is used, steps 1, 5 and 8 can be omitted. Else if a segmentation is used in 5 and 8 which does not produce overlapping sections, steps 6 and 9 can be omitted.
 

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -310,7 +310,7 @@
 				"dpi": {
 					"type": "number",
 					"format": "float",
-					"description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative",
+					"description": "pixel density in dots per inch (overrides any meta-data in the images); disabled when negative; when disabled and no meta-data is found, 300 is assumed",
 					"default": -1
 				},
 				"level-of-operation": {
@@ -323,46 +323,64 @@
 					"type": "number",
 					"format": "integer",
 					"default": 20,
-					"description": "number of white/background column separators to try, counted piece-wise (when operating on the page level)"
+					"description": "(when operating on the page/table level) maximum number of white/background column separators to detect, counted piece-wise"
 				},
 				"maxseps": {
 					"type": "number",
 					"format": "integer",
 					"default": 20,
-					"description": "number of black/foreground column separators to try, counted piece-wise (when operating on the page level)"
+					"description": "(when operating on the page/table level) number of black/foreground column separators to detect (and suppress), counted piece-wise"
+				},
+				"maximages": {
+					"type": "number",
+					"format": "integer",
+					"default": 10,
+					"description": "(when operating on the page level) maximum number of black/foreground very large components to detect (and suppress), counted piece-wise"
 				},
 				"csminheight": {
 					"type": "number",
 					"format": "integer",
 					"default": 4,
-					"description": "minimum height of white/background or black/foreground column separators in multiples of scale/capheight, counted piece-wise (when operating on the page level)"
+					"description": "(when operating on the page/table level) minimum height of white/background or black/foreground column separators in multiples of scale/capheight, counted piece-wise"
 				},
 				"hlminwidth": {
 					"type": "number",
 					"format": "integer",
 					"default": 10,
-					"description": "minimum width of black/foreground horizontal separators in multiples of scale/capheight, counted piece-wise (when operating on the page level)"
+					"description": "(when operating on the page/table level) minimum width of black/foreground horizontal separators in multiples of scale/capheight, counted piece-wise"
+				},
+				"gap_height": {
+					"type": "number",
+					"format": "float",
+					"default": 0.01,
+					"description": "(when operating on the page/table level) largest minimum pixel average in the horizontal or vertical profiles (across the binarized image) to still be regarded as a gap during recursive X-Y cut from lines to regions; needs to be larger when more foreground noise is present, reduce to avoid mistaking text for noise"
+				},
+				"gap_width": {
+					"type": "number",
+					"format": "float",
+					"default": 1.5,
+					"description": "(when operating on the page/table level) smallest width in multiples of scale/capheight of a valley in the horizontal or vertical profiles (across the binarized image) to still be regarded as a gap during recursive X-Y cut from lines to regions; needs to be smaller when more foreground noise is present, increase to avoid mistaking inter-line as paragraph gaps and inter-word as inter-column gaps"
 				},
 				"overwrite_separators": {
 					"type": "boolean",
 					"default": true,
-					"description": "remove any existing SeparatorRegion elements (when operating on the page level)"
+					"description": "(when operating on the page/table level) remove any existing SeparatorRegion elements; otherwise append"
 				},
 				"overwrite_regions": {
 					"type": "boolean",
 					"default": true,
-					"description": "remove any existing TextRegion elements (when operating on the page level)"
+					"description": "(when operating on the page/table level) remove any existing TextRegion elements; otherwise append"
 				},
 				"overwrite_lines": {
 					"type": "boolean",
 					"default": true,
-					"description": "remove any existing TextLine elements (when operating on the region level)"
+					"description": "(when operating on the region level) remove any existing TextLine elements; otherwise append"
 				},
 				"spread": {
 					"type": "number",
 					"format": "float",
 					"default": 2.4,
-					"description": "distance in points (pt) from the foreground to project text line (or text region) labels into the background; if zero, project half a scale (approx xheight)"
+					"description": "distance in points (pt) from the foreground to project text line (or text region) labels into the background for polygonal contours; if zero, project half a scale/capheight"
 				}
 			}
 		},

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -27,21 +27,29 @@
 				"method": {
 					"type": "string",
 					"enum": ["none", "global", "otsu", "gauss-otsu", "ocropy"],
-					"description": "binarization method to use (only ocropy will include deskewing)",
+					"description": "binarization method to use (only 'ocropy' will include deskewing and denoising)",
 					"default": "ocropy"
+				},
+				"threshold": {
+					"type": "number",
+					"format": "float",
+					"description": "for the 'ocropy' and ' global' method, black/white threshold to apply on the whitelevel normalized image (the larger the more/heavier foreground)",
+					"default": 0.5
 				},
 				"grayscale": {
 					"type": "boolean",
-					"description": "for the ocropy method, produce grayscale-normalized instead of thresholded image",
+					"description": "for the 'ocropy' method, produce grayscale-normalized instead of thresholded image",
 					"default": false
 				},
 				"maxskew": {
 					"type": "number",
-					"description": "modulus of maximum skewing angle to detect (larger will be slower, 0 will deactivate deskewing)",
+					"format": "float",
+					"description": "modulus of maximum skewing angle (in degrees) to detect (larger will be slower, 0 will deactivate deskewing)",
 					"default": 0.0
 				},
 				"noise_maxsize": {
 					"type": "number",
+					"format": "int",
 					"description": "maximum pixel number for connected components to regard as noise (0 will deactivate denoising)",
 					"default": 0
 				},

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -305,7 +305,7 @@
 			"output_file_grp": [
 				"OCR-D-SEG-LINE"
 			],
-			"description": "Segment pages into regions and lines, or regions into lines with ocropy",
+			"description": "Segment pages into regions and lines, tables into cells and lines, or regions into lines with ocropy",
 			"parameters": {
 				"dpi": {
 					"type": "number",
@@ -315,8 +315,8 @@
 				},
 				"level-of-operation": {
 					"type": "string",
-					"enum": ["page", "region"],
-					"description": "PAGE XML hierarchy level to read images from",
+					"enum": ["page", "table", "region"],
+					"description": "PAGE XML hierarchy level to read images from and add elements to",
 					"default": "region"
 				},
 				"maxcolseps": {
@@ -342,6 +342,11 @@
 					"format": "integer",
 					"default": 10,
 					"description": "minimum width of black/foreground horizontal separators in multiples of scale/capheight, counted piece-wise (when operating on the page level)"
+				},
+				"overwrite_separators": {
+					"type": "boolean",
+					"default": true,
+					"description": "remove any existing SeparatorRegion elements (when operating on the page level)"
 				},
 				"overwrite_regions": {
 					"type": "boolean",

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -1,6 +1,6 @@
 {
 	"git_url": "https://github.com/cisocrgroup/ocrd_cis",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"tools": {
 		"ocrd-cis-ocropy-binarize": {
 			"executable": "ocrd-cis-ocropy-binarize",
@@ -297,7 +297,7 @@
 			"output_file_grp": [
 				"OCR-D-SEG-LINE"
 			],
-			"description": "Segment pages into regions or regions into lines with ocropy",
+			"description": "Segment pages into regions and lines, or regions into lines with ocropy",
 			"parameters": {
 				"dpi": {
 					"type": "number",
@@ -314,14 +314,26 @@
 				"maxcolseps": {
 					"type": "number",
 					"format": "integer",
-					"default": 2,
-					"description": "number of white/background column separators to try (when operating on the page level)"
+					"default": 20,
+					"description": "number of white/background column separators to try, counted piece-wise (when operating on the page level)"
 				},
 				"maxseps": {
 					"type": "number",
 					"format": "integer",
-					"default": 5,
-					"description": "number of black/foreground column separators to try, counted individually as lines (when operating on the page level)"
+					"default": 20,
+					"description": "number of black/foreground column separators to try, counted piece-wise (when operating on the page level)"
+				},
+				"csminheight": {
+					"type": "number",
+					"format": "integer",
+					"default": 4,
+					"description": "minimum height of white/background or black/foreground column separators in multiples of scale/capheight, counted piece-wise (when operating on the page level)"
+				},
+				"hlminwidth": {
+					"type": "number",
+					"format": "integer",
+					"default": 10,
+					"description": "minimum width of black/foreground horizontal separators in multiples of scale/capheight, counted piece-wise (when operating on the page level)"
 				},
 				"overwrite_regions": {
 					"type": "boolean",
@@ -337,7 +349,7 @@
 					"type": "number",
 					"format": "float",
 					"default": 2.4,
-					"description": "distance in points (pt) from the foreground to project text line (or text region) labels into the background"
+					"description": "distance in points (pt) from the foreground to project text line (or text region) labels into the background; if zero, project half a scale (approx xheight)"
 				}
 			}
 		},

--- a/ocrd_cis/ocropy/binarize.py
+++ b/ocrd_cis/ocropy/binarize.py
@@ -194,9 +194,9 @@ class OcropyBinarize(Processor):
             if angle:
                 features += ',deskewed'
             page_xywh['angle'] = angle
-        bin_image = remove_noise(bin_image,
-                                 maxsize=self.parameter['noise_maxsize'])
         if self.parameter['noise_maxsize']:
+            bin_image = remove_noise(
+                bin_image, maxsize=self.parameter['noise_maxsize'])
             features += ',despeckled'
         # annotate angle in PAGE (to allow consumers of the AlternativeImage
         # to do consistent coordinate transforms, and non-consumers

--- a/ocrd_cis/ocropy/clip.py
+++ b/ocrd_cis/ocropy/clip.py
@@ -247,7 +247,7 @@ class OcropyClip(Processor):
         for neighbour, neighbour_mask in neighbours:
             # find connected components that (only) belong to the neighbour:
             intruders = segment_mask * morph.keep_marked(parent_bin, neighbour_mask > 0) # overlaps neighbour
-            intruders -= morph.keep_marked(intruders, segment_mask - neighbour_mask > 0) # but exclusively
+            intruders = morph.remove_marked(intruders, segment_mask > neighbour_mask) # but exclusively
             num_intruders = np.count_nonzero(intruders)
             num_foreground = np.count_nonzero(segment_mask * parent_bin)
             if not num_intruders:

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -456,9 +456,9 @@ def compute_images(binary, scale, maximages=5):
     
     Returns a same-size bool array as a mask image.
     """
-    d0 = odd(max(2,scale/5))
-    d1 = odd(max(2,scale/8))
     images = binary
+    # d0 = odd(max(2,scale/5))
+    # d1 = odd(max(2,scale/8))
     # 1- close a little to reconnect components that have been
     #   noisily binarized
     #images = morph.rb_closing(images, (d0,d1))
@@ -1300,14 +1300,14 @@ def lines2regions(binary, llabels,
                                                                  lpartitions[label2])
                                 lpartitions[label2] = [0]
                     # re-label and re-order surviving partitions
-                    lpartitions = np.setdiff1d(np.unique(partitions), [0]) # without bg/sepm
+                    #lpartitions = np.setdiff1d(np.unique(partitions), [0]) # without bg/sepm
                     npartitions = len(lpartitions)
                     if debug: LOG.debug('  %d sepmask partitions after filtering and merging', npartitions)
                     if npartitions > 1:
                         # sort partitions in reading order
                         order = morph.reading_order(partitions,rl,bt)
                         partitions = order[partitions]
-                        lpartitions = order[lpartitions]
+                        #lpartitions = order[lpartitions]
         
         # try cuts via h/v projection profiles
         y = np.mean(lbin>0, axis=1)

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -667,6 +667,7 @@ def compute_line_labels(array, fullpage=False, zoom=1.0, maxcolseps=2, maxseps=0
 
     sepmask = morph.r_dilation(np.maximum(colseps, np.maximum(hlines, vlines)),
                                (scale//2, scale//2))
+    #DSAVE("sepmask", sepmask + 0.6*binary)
     seeds = compute_line_seeds(binary, bottom, top, sepmask, scale)
     #DSAVE("seeds", seeds + 0.6*binary)
     if not fullpage:

--- a/ocrd_cis/ocropy/ocrolib/common.py
+++ b/ocrd_cis/ocropy/ocrolib/common.py
@@ -454,7 +454,7 @@ def load_object(fname,zip=0,nofind=0,verbose=0):
             return pickle.load(stream, encoding='latin1')
     else:
         with open(fname,"rb") as stream:
-            unpickler = pickle.Unpickler(stream)
+            unpickler = pickle.Unpickler(stream, encoding='latin1')
             #unpickler.find_global = unpickle_find_global
             return unpickler.load()
 

--- a/ocrd_cis/ocropy/ocrolib/common.py
+++ b/ocrd_cis/ocropy/ocrolib/common.py
@@ -388,7 +388,7 @@ class RegionExtractor:
         b = self.objects[index]
         # print("@@@mask", index, b)
         m = self.labels[b]
-        m[m!=index] = 0
+        m[m!=index] = 0 # FIXME: This is destructive for labels!
         if margin>0: m = pad_by(m,margin)
         return array(m!=0,'B')
     def extract(self,image,index,margin=0):

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -6,9 +6,8 @@
 
 from numpy import *
 import pylab
-from pylab import *
-from scipy.ndimage import morphology,measurements,filters
-from scipy.ndimage.morphology import *
+#from scipy.ndimage import morphology,measurements,filters
+from scipy.ndimage import measurements
 from scipy.ndimage.interpolation import shift
 import cv2
 from .toplevel import *

--- a/ocrd_cis/ocropy/ocrolib/psegutils.py
+++ b/ocrd_cis/ocropy/ocrolib/psegutils.py
@@ -129,6 +129,7 @@ def reading_order(lines,highlight=None,debug=0):
         if w[0].stop<min(u[0].start,v[0].start): return 0
         if w[0].start>max(u[0].stop,v[0].stop): return 0
         if w[1].start<u[1].stop and w[1].stop>v[1].start: return 1
+        return 0
     if highlight is not None:
         plt.clf()
         plt.title("highlight")
@@ -224,4 +225,3 @@ def rgbshow(r,g,b=None,gn=1,cn=0,ab=0,**kw):
         combo = np.abs(combo)
     if np.amin(combo)<0: print("warning: values less than zero")
     plt.imshow(np.clip(combo,0,1),**kw)
-

--- a/ocrd_cis/ocropy/ocrolib/psegutils.py
+++ b/ocrd_cis/ocropy/ocrolib/psegutils.py
@@ -28,8 +28,13 @@ def estimate_scale(binary, zoom=1.0):
     for o in bysize:
         if np.amax(scalemap[o])>0: continue
         scalemap[o] = sl.area(o)**0.5
-    scale = np.median(scalemap[(scalemap>3/zoom)&(scalemap<100/zoom)])
-    return scale
+    scalemap = scalemap[(scalemap>3/zoom)&(scalemap<100/zoom)]
+    if np.any(scalemap):
+        return int(np.median(scalemap))
+    else:
+        # empty page (only large h/v-lines or small noise)
+        # guess! (average 10 pt font: 42 px at 300 DPI)
+        return int(42/zoom)
 
 @checks(ABINARY2,NUMBER)
 def compute_boxmap(binary,scale,threshold=(.5,4),dtype='i'):

--- a/ocrd_cis/ocropy/ocrolib/psegutils.py
+++ b/ocrd_cis/ocropy/ocrolib/psegutils.py
@@ -31,13 +31,18 @@ def estimate_scale(binary, zoom=1.0):
     scale = np.median(scalemap[(scalemap>3/zoom)&(scalemap<100/zoom)])
     return scale
 
+@checks(ABINARY2,NUMBER)
 def compute_boxmap(binary,scale,threshold=(.5,4),dtype='i'):
     objects = binary_objects(binary)
     bysize = sorted(objects,key=sl.area)
     boxmap = np.zeros(binary.shape,dtype)
-    for o in bysize:
-        if sl.area(o)**.5<threshold[0]*scale: continue
-        if sl.area(o)**.5>threshold[1]*scale: continue
+    for o in reversed(bysize):
+        if sl.area(o)**.5<threshold[0]*scale:
+            # only too small boxes (noise) from here on
+            break
+        if sl.area(o)**.5>threshold[1]*scale:
+            # ignore too large box
+            continue
         boxmap[o] = 1
     return boxmap
 

--- a/ocrd_cis/ocropy/ocrolib/psegutils.py
+++ b/ocrd_cis/ocropy/ocrolib/psegutils.py
@@ -20,14 +20,15 @@ def binary_objects(binary):
     objects = morph.find_objects(labels)
     return objects
 
-def estimate_scale(binary):
+@checks(ABINARY2)
+def estimate_scale(binary, zoom=1.0):
     objects = binary_objects(binary)
     bysize = sorted(objects,key=sl.area)
     scalemap = np.zeros(binary.shape)
     for o in bysize:
         if np.amax(scalemap[o])>0: continue
         scalemap[o] = sl.area(o)**0.5
-    scale = np.median(scalemap[(scalemap>3)&(scalemap<100)])
+    scale = np.median(scalemap[(scalemap>3/zoom)&(scalemap<100/zoom)])
     return scale
 
 def compute_boxmap(binary,scale,threshold=(.5,4),dtype='i'):

--- a/ocrd_cis/ocropy/ocrolib/sl.py
+++ b/ocrd_cis/ocropy/ocrolib/sl.py
@@ -70,6 +70,14 @@ def intersect(u,v):
     if u is None: return v
     if v is None: return u
     return tuple([slice(max(u[i].start,v[i].start),min(u[i].stop,v[i].stop)) for i in range(len(u))])
+def compose(u,v):
+    """Compute the composition of the two slice lists.
+    
+    (``v`` addresses the subspace created by ``u``)
+    """
+    if u is None: return v
+    if v is None: return u
+    return tuple([slice(u[i].start+v[i].start,min(u[i].stop,u[i].start+v[i].stop)) for i in range(len(u))])
 
 def xoverlap(u,v):
     return max(0,min(u[1].stop,v[1].stop)-max(u[1].start,v[1].start))
@@ -96,13 +104,26 @@ def ycenter(s):
 def center(s):
     return (ycenter(s),xcenter(s))
 def center_in(u,v):
-    y,x = ycenter(u),xcenter(u)
-    return y>=v[0].start and y<=v[0].stop and x>=v[1].start and x<=v[1].stop
+    return xcenter_in(u,v) and ycenter_in(u,v)
+def xcenter_in(u,v):
+    x = xcenter(u)
+    return x>=v[1].start and x<=v[1].stop
+def ycenter_in(u,v):
+    y = ycenter(u)
+    return y>=v[0].start and y<=v[0].stop
 
 def width(s):
     return s[1].stop-s[1].start
 def height(s):
     return s[0].stop-s[0].start
+def top(s):
+    return s[0].start
+def bottom(s):
+    return s[0].stop
+def left(s):
+    return s[1].start
+def right(s):
+    return s[1].stop
 
 ### Functions with mathematical coordinate conventions
 

--- a/ocrd_cis/ocropy/ocrolib/time_morphology.py
+++ b/ocrd_cis/ocropy/ocrolib/time_morphology.py
@@ -1,0 +1,110 @@
+from scipy.ndimage import morphology,filters,measurements
+import numpy as np
+from PIL import Image
+from ocrd_cis.ocropy import common
+import cv2
+
+# compares performance of different implementations for image morphology:
+# (in order of runtime, slowest first)
+# - SciPy morphology/measurements
+# - SciPy uniform filter
+# - SciPy min/max filter
+# - OpenCV
+
+def cv_opening(bin, size):
+    # note: calling with *even* size dimensions will cause 1-off errors after erosion!
+    return cv2.morphologyEx(bin.astype(np.uint8), cv2.MORPH_OPEN, np.ones(size, np.uint8))
+
+def cv_closing(bin, size):
+    # note: calling with *even* size dimensions will cause 1-off errors after erosion!
+    return cv2.morphologyEx(bin.astype(np.uint8), cv2.MORPH_CLOSE, np.ones(size, np.uint8))
+
+def cv_label(bin):
+    n, labels = cv2.connectedComponents(bin.astype(np.uint8))
+    return labels, n
+
+def cv_contours(bin):
+    contours, _ = cv2.findContours(bin.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    # convert to y,x tuples
+    return zip((contour[:,0,::-1], cv2.contourArea(contour)) for contour in contours)
+
+def rb_opening(bin, size):
+    return filters.uniform_filter(filters.uniform_filter(bin, size, np.float, mode='constant', cval=1) == 1, size, np.float, origin=-1) > 1e-7
+
+def rb_closing(bin, size):
+    return filters.uniform_filter(filters.uniform_filter(bin, size, np.float) > 1e-7, size, mode='constant', cval=1, origin=-1) == 1
+
+def r_closing(bin, size):
+    return filters.minimum_filter(filters.maximum_filter(bin, size), size, origin=-1)
+
+def r_opening(bin, size):
+    return filters.maximum_filter(filters.minimum_filter(bin, size), size, origin=-1)
+
+def nd_closing(bin, size):
+    return morphology.binary_closing(bin, np.ones(size))
+
+def nd_opening(bin, size):
+    return morphology.binary_opening(bin, np.ones(size))
+
+def nd_label(bin):
+    return measurements.label(bin)
+
+#def sk_contours ...
+# skimage.measure.find_contours is impractical:
+# - interrupts hull polygon when it intersects the margins (!)
+# - uses 0.5-based coordinates (i.e. center of pixel instead of top/left)
+
+def load(path):
+    img = Image.open(path)
+    return common.pil2array(img)==0
+
+def test_cv(bin):
+    cv_opening(cv_closing(bin, (20,10)), (3,2))
+
+def test2_cv(bin):
+    cv_label(bin)
+
+def test3_cv(bin):
+    closed = cv_closing(bin, (int(bin.shape[0]//20),int(bin.shape[1]//20)))
+    labels, n = cv_label(closed)
+    return labels, n
+
+def test4_cv(bin):
+    labels, n = test3_cv(bin)
+    contours = list([])
+    for label in range(1, n+1):
+        contours.append(cv_contours(labels==label))
+    return contours
+
+def test_rb(bin):
+    rb_opening(rb_closing(bin, (20,10)), (3,2))
+
+def test_r(bin):
+    r_opening(r_closing(bin, (20,10)), (3,2))
+
+def test_nd(bin):
+    nd_opening(nd_closing(bin, (20,10)), (3,2))
+
+def test2_nd(bin):
+    nd_label(bin)
+
+if __name__ == '__main__':
+    import timeit
+    import sys
+    path = sys.argv[1]
+    print('testing open/close based on opencv') # 0.14s
+    print(timeit.timeit("test_cv(bin)", setup="from __main__ import test_cv, load; bin = load('%s')" % path, number=10))
+    print('testing open/close based on scipy.nd maxi/minimum_filter') # 3.2s
+    print(timeit.timeit("test_r(bin)", setup="from __main__ import test_r, load; bin = load('%s')" % path, number=10))
+    print('testing open/close based on scipy.nd uniform_filter') # 3.8s
+    print(timeit.timeit("test_rb(bin)", setup="from __main__ import test_rb, load; bin = load('%s')" % path, number=10))
+    print('testing open/close based on scipy.nd morphology') # 17.3s
+    print(timeit.timeit("test_nd(bin)", setup="from __main__ import test_nd, load; bin = load('%s')" % path, number=10))
+    print('testing component analysis based on opencv') # 0.5s
+    print(timeit.timeit("test2_cv(bin)", setup="from __main__ import test2_cv, load; bin = load('%s')" % path, number=100))
+    print('testing component analysis based on scipy.nd measurements') # 3.4s
+    print(timeit.timeit("test2_nd(bin)", setup="from __main__ import test2_nd, load; bin = load('%s')" % path, number=100))
+    print('testing component analysis after close based on opencv') # 8.4s
+    print(timeit.timeit("test3_cv(bin)", setup="from __main__ import test3_cv, load; bin = load('%s')" % path, number=100))
+    print('testing contours after CA after close based on opencv') # 12.4s
+    print(timeit.timeit("test4_cv(bin)", setup="from __main__ import test4_cv, load; bin = load('%s')" % path, number=100))

--- a/ocrd_cis/ocropy/ocrolib/toplevel.py
+++ b/ocrd_cis/ocropy/ocrolib/toplevel.py
@@ -286,7 +286,7 @@ except: pass
 def AFLOAT(a):
     return a.dtype in float_dtypes
 
-int_dtypes = [np.dtype('uint8'),np.dtype('int32'),np.dtype('int64'),np.dtype('uint32'),np.dtype('uint64')]
+int_dtypes = [np.dtype('uint8'),np.dtype('uint16'),np.dtype('int32'),np.dtype('int64'),np.dtype('uint32'),np.dtype('uint64')]
 
 @makeargcheck("array must contain integer values")
 def AINT(a):

--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -236,7 +236,7 @@ class OcropyRecognize(Processor):
             # process ocropy:
             try:
                 linepred, clist, rlist, confidlist = recognize(
-                    final_img, pad, self.network, check=True)
+                    final_img, self.pad, self.network, check=True)
             except Exception as err:
                 LOG.debug('ERROR: error processing line "%s": %s', line.id, err)
                 continue

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -108,7 +108,7 @@ def resegment(line_polygon, region_labels, region_bin, line_id,
     # can produce invalid (self-intersecting) polygons:
     #polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
     polygon = contour[:, 0, ::] # already ordered x,y
-    polygon = Polygon(polygon).simplify(2).exterior.coords
+    polygon = Polygon(polygon).simplify(2).exterior.coords[:-1] # keep open
     if len(polygon) < 4:
         LOG.warning('found no contour of >=4 points for line "%s"', line_id)
         return None

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -25,7 +25,6 @@ from ocrd_utils import (
 )
 
 from .. import get_ocrd_tool
-from . import common
 from .ocrolib import midrange
 from .common import (
     pil2array,
@@ -96,13 +95,12 @@ def resegment(line_polygon, region_labels, region_bin, line_id,
     max_contour = np.argmax(contour_areas)
     max_area = contour_areas[max_contour]
     total_area = cv2.contourArea(np.expand_dims(line_polygon, 1))
-    # if max_area / total_area < 0.5 * threshold_relative:
-    #     # using a different, more conservative threshold here:
-    #     # avoid being overly strict with cropping background,
-    #     # just ensure the contours are not a split of the mask
-    #     LOG.info('Largest label (%d) largest contour (%d) is too small (%d/%d) in line "%s"',
-    #              max_label, max_contour, max_area, total_area, line_id)
-    #     return None
+    if max_area / total_area < 0.5 * threshold_relative:
+        # using a different, more conservative threshold here:
+        # avoid being overly strict with cropping background,
+        # just ensure the contours are not a split of the mask
+        LOG.warning('Largest label (%d) largest contour (%d) is small (%d/%d) in line "%s"',
+                    max_label, max_contour, max_area, total_area, line_id)
     contour = contours[max_contour]
     # simplify shape:
     # can produce invalid (self-intersecting) polygons:

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -220,7 +220,7 @@ class OcropyResegment(Processor):
                 try:
                     if report:
                         raise Exception(report)
-                    region_labels, _, _, _, _ = compute_segmentation(region_bin, zoom=zoom)
+                    region_labels, _, _, _, _, _ = compute_segmentation(region_bin, zoom=zoom)
                 except Exception as err:
                     LOG.warning('Cannot line-segment page "%s" region "%s": %s',
                                 page_id, region.id, err)

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -30,6 +30,7 @@ from .ocrolib import midrange
 from .common import (
     pil2array,
     # binarize,
+    check_region,
     compute_segmentation
     #borderclean_bin
 )
@@ -215,8 +216,11 @@ class OcropyResegment(Processor):
                 region_array = pil2array(region_image)
                 #region_array, _ = common.binarize(region_array, maxskew=0) # just in case still raw
                 region_bin = np.array(region_array <= midrange(region_array), np.bool)
+                report = check_region(region_bin, zoom)
                 try:
-                    region_labels, _, _, _, _ = compute_segmentation(region_array, zoom=zoom)
+                    if report:
+                        raise Exception(report)
+                    region_labels, _, _, _, _ = compute_segmentation(region_bin, zoom=zoom)
                 except Exception as err:
                     LOG.warning('Cannot line-segment page "%s" region "%s": %s',
                                 page_id, region.id, err)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -4,6 +4,7 @@ import os.path
 import numpy as np
 from skimage import draw
 import cv2
+from shapely.geometry import Polygon
 
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import (
@@ -76,7 +77,10 @@ def segment(line_labels, region_bin, region_id):
                             label, i, area, total_area, region_id)
                 continue
             # simplify shape:
-            polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
+            # can produce invalid (self-intersecting) polygons:
+            #polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
+            polygon = contour[:, 0, ::] # already ordered x,y
+            polygon = Polygon(polygon).simplify(2).exterior.coords
             if len(polygon) < 4:
                 LOG.warning('Line label %d contour %d has less than 4 points for region "%s"',
                             label, i, region_id)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -104,7 +104,7 @@ def masks2polygons(bg_labels, fg_bin, name, min_area=None):
             # can produce invalid (self-intersecting) polygons:
             #polygon = cv2.approxPolyDP(contour, 2, False)[:, 0, ::] # already ordered x,y
             polygon = contour[:, 0, ::] # already ordered x,y
-            polygon = Polygon(polygon).simplify(2).exterior.coords
+            polygon = Polygon(polygon).simplify(2).exterior.coords[:-1] # keep open
             if len(polygon) < 4:
                 LOG.warning('Label %d contour %d has less than 4 points for %s',
                             label, i, name)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -276,12 +276,7 @@ class OcropySegment(Processor):
                     else:
                         LOG.warning('keeping existing TextRegions in page "%s"', page_id)
                         ignore.extend(regions)
-                if not ro:
-                    ro = ReadingOrderType()
-                    page.set_ReadingOrder(ro)
                 # create reading order if necessary
-                reading_order = dict()
-                ro = page.get_ReadingOrder()
                 if not ro:
                     ro = ReadingOrderType()
                     page.set_ReadingOrder(ro)
@@ -563,22 +558,22 @@ class OcropySegment(Processor):
                                                    min_area=640/zoom/zoom)
                     # create new lines in new regions
                     line_polys = [Polygon(polygon) for _, polygon in line_polygons]
-                    for region_no, (_, polygon) in enumerate(region_polygons, region_no+1):
-                        region_poly = prep(Polygon(polygon))
+                    for region_no, (_, region_polygon) in enumerate(region_polygons, region_no+1):
+                        region_poly = prep(Polygon(region_polygon))
                         # convert back to absolute (page) coordinates:
-                        region_polygon = coordinates_for_segment(polygon, image, coords)
+                        region_polygon = coordinates_for_segment(region_polygon, image, coords)
                         # annotate result:
                         region_id = element_id + "_region%04d" % region_no
                         LOG.debug('Region label %d becomes ID "%s"', region_label, region_id)
                         region = TextRegionType(id=region_id, Coords=CoordsType(
                             points=points_from_polygon(region_polygon)))
                         # find out which line (contours) belong to which region (contours)
-                        for line_no, (line_label, polygon) in enumerate(line_polygons):
+                        for line_no, (line_label, line_polygon) in enumerate(line_polygons):
                             line_poly = line_polys[line_no]
                             if not region_poly.intersects(line_poly): # contains
                                 continue
                             # convert back to absolute (page) coordinates:
-                            line_polygon = coordinates_for_segment(polygon, image, coords)
+                            line_polygon = coordinates_for_segment(line_polygon, image, coords)
                             # annotate result:
                             line_id = region_id + "_line%04d" % line_no
                             LOG.debug('Line label %d becomes ID "%s"', line_label, line_id)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -523,7 +523,8 @@ class OcropySegment(Processor):
                         if line_label <= len(ignore):
                             # existing region from `ignore` merely to be ordered
                             # (no new region, no actual text line)
-                            index = page_add_to_reading_order(rogroup, ignore[line_label-1].id, index)
+                            if rogroup:
+                                index = page_add_to_reading_order(rogroup, ignore[line_label-1].id, index)
                             LOG.debug('Region label %d line label %d is for ignored region "%s"',
                                       region_label, line_label, ignore[line_label-1].id)
                         else:
@@ -545,7 +546,8 @@ class OcropySegment(Processor):
                                 element.add_TextRegion(region)
                                 LOG.info('Added region "%s" with 1 line for %s "%s"',
                                          region_id, element_name, element_id)
-                                index = page_add_to_reading_order(rogroup, region.id, index)
+                                if rogroup:
+                                    index = page_add_to_reading_order(rogroup, region.id, index)
                 else:
                     # normal case: new lines inside new regions
                     # find contours for region (can be non-contiguous)
@@ -584,7 +586,8 @@ class OcropySegment(Processor):
                             element.add_TextRegion(region)
                             LOG.info('Added region "%s" with %d lines for %s "%s"',
                                      region_id, len(line_polygons), element_name, element_id)
-                            index = page_add_to_reading_order(rogroup, region.id, index)
+                            if rogroup:
+                                index = page_add_to_reading_order(rogroup, region.id, index)
             # add additional image/non-text regions from compute_segmentation
             # (e.g. drop-capitals or images) ...
             image_labels, num_images = morph.label(images)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with codecs.open('README.md', encoding='utf-8') as f:
 
 setup(
     name='ocrd_cis',
-    version='0.0.6',
+    version='0.0.7',
     description='CIS OCR-D command line tools',
     long_description=README,
     long_description_content_type='text/markdown',
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'ocrd>=2.0.0',
+        'ocrd>=2.4.0',
         'click',
         'scipy',
         'numpy>=1.17.0',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         'numpy>=1.17.0',
         'pillow>=6.2.0',
         'shapely',
+        'scikit-image',
+        'opencv-python-headless',
         'matplotlib>3.0.0',
         'python-Levenshtein',
         'calamari_ocr == 0.3.5'


### PR DESCRIPTION
This is a major rework of Ocropy's rule-based segmentation.

It greatly improves the situation with some long-standing problems, among them…
- DPI relativity (again)
- robust h/v-line separator detection (again)
- text/image segmentation (sort-of)
- conflation of very close text lines (vertically due to ascenders/descenders, horizontally due to noise)
- _reading order_
- _performance_ (OpenCV and PIL instead of SciPy)

…but also offers solutions to unchartered terrain (for ocropus/ocrolib, that is)…
- _page segmentation_ into regions (via new variant of recursive X-Y cut)
- table recognition (but not detection!)
- incremental annotation (ignoring but sorting existing regions, deleting existing text regions from reading order)

The OCR-D processor most affected by this is `ocrd-cis-ocropy-segment` (now with a usable `level-of-operation=page` and a new `level-of-operation=table`), and to a lesser extent `ocrd-cis-ocropy-resegment`.

For the details, see changelog of the individual commits.

Here's from the `segment` processor docstring:

> Segment pages into regions+lines, tables into cells+lines, or regions into lines.

> Open and deserialise PAGE input files and their respective images,
> then iterate over the element hierarchy down to the requested level.

> Depending on ``level-of-operation``, consider existing segments:
> - if ``overwrite_separators=True`` on ``page`` level, then
>   delete any SeparatorRegions,
> - if ``overwrite_regions=True`` on ``page`` level, then
>   delete any top-level TextRegions (along with ReadingOrder),
> - if ``overwrite_regions=True`` on ``table`` level, then
>   delete any TextRegions in TableRegions (along with their OrderGroup),
> - if ``overwrite_lines=True`` on ``region`` level, then
>   delete any TextLines in TextRegions.

> Next, get each element image according to the layout annotation (from
> the alternative image of the page/region, or by cropping via coordinates
> into the higher-level image) in binarized form, and represent it as an array
> with non-text regions and (remaining) text neighbours suppressed.

> Then compute a text line segmentation for that array (as a label mask).
> When ``level-of-operation`` is ``page`` or ``table``, this also entails
> detecting
> - up to ``maximages`` large foreground images,
> - up to ``maxseps`` foreground h/v-line separators and
> - up to ``maxcolseps`` background column separators
> before text line segmentation itself, as well as aggregating text lines
> to text regions afterwards.

> Text regions are detected via a hybrid variant recursive X-Y cut algorithm
> (RXYC): RXYC partitions the binarized image in top-down manner by detecting
> horizontal or vertical gaps. This implementation uses the bottom-up text line
> segmentation to guide the search, and also uses both pre-existing and newly
> detected separators to alternatively partition the respective boxes into
> non-rectangular parts.

> During line segmentation, suppress the foreground of all previously annotated
> regions (of any kind) and lines, except if just removed due to ``overwrite``.
> During region aggregation however, combine the existing separators with the
> new-found separators to guide the column search.

> All detected segments (both text line and text region) are sorted according
> to their reading order (assuming a top-to-bottom, left-to-right ordering).
> When ``level-of-operation`` is ``page``, prefer vertical (column-first)
> succession of regions. When it is ``table``, prefer horizontal (row-first)
> succession of cells.

> Then for each resulting segment label, convert its background mask into
> polygon outlines by finding the outer contours consistent with the element's
> polygon outline. Annotate the result by adding it as a new TextLine/TextRegion:
> - If ``level-of-operation`` is ``region``, then append the new lines to the
>   parent region.
> - If it is ``table``, then append the new lines to their respective regions,
>   and append the new regions to the parent table.
>   (Also, create an OrderedGroup for it as the parent's RegionRef.)
> - If it is ``page``, then append the new lines to their respective regions,
>   and append the new regions to the page.
>   (Also, create an OrderedGroup for it in the ReadingOrder.)

> Produce a new output file by serialising the resulting hierarchy.

(Example images following shortly.)