### PR TITLE
load gzipped models

### DIFF
--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -131,7 +131,7 @@ class OcropyRecognize(Processor):
         Produce a new output file by serialising the resulting hierarchy.
         """
         # from ocropus-rpred:
-        self.network = load_object(self.get_model(), verbose=1)
+        self.network = load_object(self.get_model(), zip=1, verbose=1)
         for x in self.network.walk():
             x.postLoad()
         for x in self.network.walk():


### PR DESCRIPTION
pyrnn models are generally distributed gzipped. If loading gzipped models is inefficient, I can also adapt https://github.com/OCR-D/ocrd_all/pull/103 to gunzip models after download.