### PR TITLE
only override log level if it is actually set

### DIFF
--- a/ocrd_cis/align/cli.py
+++ b/ocrd_cis/align/cli.py
@@ -19,7 +19,7 @@ LOG_LEVEL = 'INFO'
 @click.command()
 @ocrd_cli_options
 def ocrd_cis_align(*args, **kwargs):
-    if 'log_level' in kwargs:
+    if 'log_level' in kwargs and kwargs['log_level']:
         global LOG_LEVEL
         LOG_LEVEL = kwargs['log_level']
     return ocrd_cli_wrap_processor(Aligner, *args, **kwargs)

--- a/ocrd_cis/postcorrect/cli.py
+++ b/ocrd_cis/postcorrect/cli.py
@@ -15,7 +15,7 @@ LOG_LEVEL = 'INFO'
 @click.command()
 @ocrd_cli_options
 def ocrd_cis_postcorrect(*args, **kwargs):
-    if 'log_level' in kwargs:
+    if 'log_level' in kwargs and kwargs['log_level']:
         global LOG_LEVEL
         LOG_LEVEL = kwargs['log_level']
     return ocrd_cli_wrap_processor(PostCorrector, *args, **kwargs)


### PR DESCRIPTION
Something is going wrong with passing of log level to the java wrappers. With the current version, @EEngl52 encountered this issue:

```
ocrd-cis-postcorrect -I OCR-D-ALIGN -  O OCR-D-POST -p '/test/data/post-correct.json'
18:25:19.126 INFO ocrd.workspace_validator - input_file_grp=['OCR-D-ALIGN'] outp  ut_file_grp=['OCR-D-POST']
{
    "profilerPath": "/test/data/profile.bash",
    "profilerConfig": "ignored",
    "model": "/home/habocr/ocrd_cis/ocrd_cis/data/model.zip",
    "nOCR": 2,
    "maxCandidates": 10,
    "runLE": false,
    "profiler": {
        "path": "/test/data/profile.bash",
        "config": "ignored",
        "noCache": true
    },
    "runDM": true
}
Traceback (most recent call last):
  File "/home/habocr/.local/bin/ocrd-cis-postcorrect", line 11, in <module>
    load_entry_point('ocrd-cis==0.0.9', 'console_scripts', 'ocrd-cis-postcorrect  ')()
  File "/home/habocr/.local/lib/python3.6/site-packages/click/core.py", line 829  , in __call__
    return self.main(*args, **kwargs)
  File "/home/habocr/.local/lib/python3.6/site-packages/click/core.py", line 782  , in main
    rv = self.invoke(ctx)
  File "/home/habocr/.local/lib/python3.6/site-packages/click/core.py", line 106  6, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/habocr/.local/lib/python3.6/site-packages/click/core.py", line 610  , in invoke
    return callback(*args, **kwargs)
  File "/home/habocr/.local/lib/python3.6/site-packages/ocrd_cis/postcorrect/cli  .py", line 21, in ocrd_cis_postcorrect
    return ocrd_cli_wrap_processor(PostCorrector, *args, **kwargs)
  File "/home/habocr/.local/lib/python3.6/site-packages/ocrd/decorators.py", lin  e 54, in ocrd_cli_wrap_processor
    run_processor(processorClass, ocrd_tool, mets, workspace=workspace, **kwargs  )
  File "/home/habocr/.local/lib/python3.6/site-packages/ocrd/processor/base.py",   line 60, in run_processor
    processor.process()
  File "/home/habocr/.local/lib/python3.6/site-packages/ocrd_cis/postcorrect/cli  .py", line 43, in process
    p.exe()
  File "/home/habocr/.local/lib/python3.6/site-packages/ocrd_cis/javaprocess.py"  , line 69, in exe
    self.log.info('command: %s', " ".join(cmd))
TypeError: sequence item 9: expected str instance, NoneType found
```

The 10th argument in the list is `loglvl` which apparently was `None`.

Running with an explicit `-l DBEUG` override will not trigger the issue.

Problem occurs in a log statement, so maybe making that more robust against non-`str` values is also a good idea for future debugging.