### PR TITLE
segment: add param 'overwrite_order'

### DIFF
--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -1,6 +1,6 @@
 {
 	"git_url": "https://github.com/cisocrgroup/ocrd_cis",
-	"version": "0.0.8",
+	"version": "0.0.10",
 	"tools": {
 		"ocrd-cis-ocropy-binarize": {
 			"executable": "ocrd-cis-ocropy-binarize",

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -365,6 +365,11 @@
 					"default": 1.5,
 					"description": "(when operating on the page/table level) smallest width in multiples of scale/capheight of a valley in the horizontal or vertical profiles (across the binarized image) to still be regarded as a gap during recursive X-Y cut from lines to regions; needs to be smaller when more foreground noise is present, increase to avoid mistaking inter-line as paragraph gaps and inter-word as inter-column gaps"
 				},
+				"overwrite_order": {
+					"type": "boolean",
+					"default": true,
+					"description": "(when operating on the page/table level) remove any references for existing TextRegion elements within the top (page/table) reading order; otherwise append"
+				},
 				"overwrite_separators": {
 					"type": "boolean",
 					"default": true,

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1300,7 +1300,7 @@ def lines2regions(binary, llabels,
                                                                  lpartitions[label2])
                                 lpartitions[label2] = [0]
                     # re-label and re-order surviving partitions
-                    #lpartitions = np.setdiff1d(np.unique(partitions), [0]) # without bg/sepm
+                    lpartitions = np.setdiff1d(np.unique(partitions), [0]) # without bg/sepm
                     npartitions = len(lpartitions)
                     if debug: LOG.debug('  %d sepmask partitions after filtering and merging', npartitions)
                     if npartitions > 1:

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,12 @@ from setuptools import find_packages
 with codecs.open('README.md', encoding='utf-8') as f:
     README = f.read()
 
+with open('./ocrd-tool.json', 'r') as f:
+    version = json.load(f)['version']
+
 setup(
     name='ocrd_cis',
-    version='0.0.9',
+    version=version,
     description='CIS OCR-D command line tools',
     long_description=README,
     long_description_content_type='text/markdown',
@@ -34,11 +37,11 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'ocrd>=2.4.0',
+        'ocrd>=2.10.4',
         'click',
         'scipy',
         'numpy>=1.17.0',
-        'pillow>=6.2.0',
+        'pillow>=7.1.2',
         'shapely',
         'scikit-image',
         'opencv-python-headless',


### PR DESCRIPTION
This allows setting `"overwrite_regions": false` while still keeping `"overwrite_order": true` – using the recursive XY cut merely to re-order the existing (and new) text regions.