### PR TITLE
Alternativeimage same filegrp

### DIFF
--- a/ocrd_cis/ocropy/binarize.py
+++ b/ocrd_cis/ocropy/binarize.py
@@ -9,7 +9,8 @@ from PIL import Image
 
 from ocrd_utils import (
     getLogger,
-    concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     MIMETYPE_PAGE
 )
 from ocrd_modelfactory import page_from_file
@@ -104,15 +105,12 @@ class OcropyBinarize(Processor):
         Produce a new output file by serialising the resulting hierarchy.
         """
         level = self.parameter['level-of-operation']
-        assert len(self.output_file_grp.split(',')) == 1, \
-            "Expected exactly one output file group, but '%s' has %d" % (
-                self.output_file_grp, len(self.output_file_grp.split(',')))
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
+            file_id = make_file_id(input_file, self.output_file_grp)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -160,9 +158,6 @@ class OcropyBinarize(Processor):
                                           file_id + '_' + region.id + '_' + line.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
             file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,

--- a/ocrd_cis/ocropy/binarize.py
+++ b/ocrd_cis/ocropy/binarize.py
@@ -31,7 +31,6 @@ from .common import (
 
 TOOL = 'ocrd-cis-ocropy-binarize'
 LOG = getLogger('processor.OcropyBinarize')
-FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-BIN'
 
 def binarize(pil_image, method='ocropy', maxskew=2, threshold=0.5, nrm=False):
     LOG.debug('binarizing %dx%d image with method=%s', pil_image.width, pil_image.height, method)
@@ -81,12 +80,6 @@ class OcropyBinarize(Processor):
                 LOG.critical('requested method %s does not support grayscale normalized output',
                              self.parameter['method'])
                 raise Exception('only method=ocropy allows grayscale=true')
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_FILEGRP_IMG
-                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Binarize (and optionally deskew/despeckle) the pages/regions/lines of the workspace.
@@ -102,21 +95,24 @@ class OcropyBinarize(Processor):
         by removing connected components smaller than ``noise_maxsize``.
         Finally, apply results to the image and export it as an image file.
 
-        Add the new image file to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or ``OCR-D-IMG-BIN``,
-        and an ID based on input file and input element.
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-BIN`` along with further
+        identification of the input element.
 
         Reference each new image in the AlternativeImage of the element.
 
         Produce a new output file by serialising the resulting hierarchy.
         """
         level = self.parameter['level-of-operation']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.image_grp, n)
+                file_id = concat_padded(self.output_file_grp, n)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -164,19 +160,19 @@ class OcropyBinarize(Processor):
                                           file_id + '_' + region.id + '_' + line.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.page_grp, n)
-            file_path = os.path.join(self.page_grp, file_id + '.xml')
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,
-                file_grp=self.page_grp,
+                file_grp=self.output_file_grp,
                 pageId=input_file.pageId,
                 local_filename=file_path,
                 mimetype=MIMETYPE_PAGE,
                 content=to_xml(pcgts))
             LOG.info('created file ID: %s, file_grp: %s, path: %s',
-                     file_id, self.page_grp, out.local_filename)
+                     file_id, self.output_file_grp, out.local_filename)
 
     def process_page(self, page, page_image, page_xywh, page_id, file_id):
         LOG.info("About to binarize page '%s'", page_id)
@@ -207,15 +203,16 @@ class OcropyBinarize(Processor):
         page.set_orientation(orientation)
         # update METS (add the image file):
         if self.parameter['grayscale']:
-            file_id += '.nrm'
+            file_id += '.IMG-NRM'
             features += ',grayscale_normalized'
         else:
+            file_id += '.IMG-BIN'
             features += ',binarized'
         file_path = self.workspace.save_image_file(
             bin_image,
             file_id,
             page_id=page_id,
-            file_grp=self.image_grp)
+            file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         page.add_AlternativeImage(AlternativeImageType(
             filename=file_path,
@@ -251,15 +248,16 @@ class OcropyBinarize(Processor):
         region.set_orientation(orientation)
         # update METS (add the image file):
         if self.parameter['grayscale']:
-            file_id += '.nrm'
+            file_id += '.IMG-NRM'
             features += ',grayscale_normalized'
         else:
+            file_id += '.IMG-BIN'
             features += ',binarized'
         file_path = self.workspace.save_image_file(
             bin_image,
             file_id,
             page_id=page_id,
-            file_grp=self.image_grp)
+            file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         region.add_AlternativeImage(AlternativeImageType(
             filename=file_path,
@@ -289,15 +287,16 @@ class OcropyBinarize(Processor):
             features += ',despeckled'
         # update METS (add the image file):
         if self.parameter['grayscale']:
-            file_id += '.nrm'
+            file_id += '.IMG-NRM'
             features += ',grayscale_normalized'
         else:
+            file_id += '.IMG-BIN'
             features += ',binarized'
         file_path = self.workspace.save_image_file(
             bin_image,
             file_id,
             page_id=page_id,
-            file_grp=self.image_grp)
+            file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         line.add_AlternativeImage(AlternativeImageType(
             filename=file_path,

--- a/ocrd_cis/ocropy/clip.py
+++ b/ocrd_cis/ocropy/clip.py
@@ -16,7 +16,8 @@ from ocrd_models.ocrd_page import (
 from ocrd import Processor
 from ocrd_utils import (
     getLogger,
-    concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     coordinates_of_segment,
     polygon_from_points,
     bbox_from_polygon,
@@ -80,15 +81,12 @@ class OcropyClip(Processor):
         # deskewing, because that would make segments incomensurable with their
         # neighbours.
         level = self.parameter['level-of-operation']
-        assert len(self.output_file_grp.split(',')) == 1, \
-            "Expected exactly one output file group, but '%s' has %d" % (
-                self.output_file_grp, len(self.output_file_grp.split(',')))
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
+            file_id = make_file_id(input_file, self.output_file_grp)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -213,9 +211,6 @@ class OcropyClip(Processor):
                                              input_file.pageId, file_id + '_' + region.id + '_' + line.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
             file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,

--- a/ocrd_cis/ocropy/clip.py
+++ b/ocrd_cis/ocropy/clip.py
@@ -35,7 +35,6 @@ from .common import (
 
 TOOL = 'ocrd-cis-ocropy-clip'
 LOG = getLogger('processor.OcropyClip')
-FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-CLIP'
 
 class OcropyClip(Processor):
 
@@ -44,13 +43,6 @@ class OcropyClip(Processor):
         kwargs['ocrd_tool'] = self.ocrd_tool['tools'][TOOL]
         kwargs['version'] = self.ocrd_tool['version']
         super(OcropyClip, self).__init__(*args, **kwargs)
-        if hasattr(self, 'output_file_grp'):
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_FILEGRP_IMG
-                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Clip text regions / lines of the workspace at intersections with neighbours.
@@ -69,9 +61,9 @@ class OcropyClip(Processor):
         which are only contained in the neighbour by clipping them to white (background),
         and export the (final) result as image file.
 
-        Add the new image file to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or ``OCR-D-IMG-CLIP``,
-        and an ID based on the input file and input element.
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-CLIP`` along with further
+        identification of the input element.
 
         Reference each new image in the AlternativeImage of the element.
 
@@ -88,12 +80,15 @@ class OcropyClip(Processor):
         # deskewing, because that would make segments incomensurable with their
         # neighbours.
         level = self.parameter['level-of-operation']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.image_grp, n)
+                file_id = concat_padded(self.output_file_grp, n)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -218,19 +213,19 @@ class OcropyClip(Processor):
                                              input_file.pageId, file_id + '_' + region.id + '_' + line.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.page_grp, n)
-            file_path = os.path.join(self.page_grp, file_id + '.xml')
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,
-                file_grp=self.page_grp,
+                file_grp=self.output_file_grp,
                 pageId=input_file.pageId,
                 local_filename=file_path,
                 mimetype=MIMETYPE_PAGE,
                 content=to_xml(pcgts))
             LOG.info('created file ID: %s, file_grp: %s, path: %s',
-                     file_id, self.page_grp, out.local_filename)
+                     file_id, self.output_file_grp, out.local_filename)
 
     def process_segment(self, segment, segment_mask, segment_polygon, neighbours,
                         background_image, parent_image, parent_coords, parent_bin,
@@ -270,9 +265,9 @@ class OcropyClip(Processor):
         # update METS (add the image file):
         file_path = self.workspace.save_image_file(
             segment_image,
-            file_id=file_id,
+            file_id=file_id + '.IMG-CLIP',
             page_id=page_id,
-            file_grp=self.image_grp)
+            file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         segment.add_AlternativeImage(AlternativeImageType(
             filename=file_path,

--- a/ocrd_cis/ocropy/denoise.py
+++ b/ocrd_cis/ocropy/denoise.py
@@ -22,7 +22,6 @@ from .common import (
 
 TOOL = 'ocrd-cis-ocropy-denoise'
 LOG = getLogger('processor.OcropyDenoise')
-FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-DESPECK'
 
 class OcropyDenoise(Processor):
 
@@ -31,13 +30,6 @@ class OcropyDenoise(Processor):
         kwargs['ocrd_tool'] = self.ocrd_tool['tools'][TOOL]
         kwargs['version'] = self.ocrd_tool['version']
         super(OcropyDenoise, self).__init__(*args, **kwargs)
-        if hasattr(self, 'output_file_grp'):
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_FILEGRP_IMG
-                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Despeckle the pages / regions / lines of the workspace.
@@ -52,21 +44,24 @@ class OcropyDenoise(Processor):
         smaller than ``noise_maxsize``. Apply results to the image and export
         it as an image file.
 
-        Add the new image file to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or ``OCR-D-IMG-DESPECK``,
-        and an ID based on input file and input element.
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-DESPECK`` along with further
+        identification of the input element.
 
         Reference each new image in the AlternativeImage of the element.
 
         Produce a new output file by serialising the resulting hierarchy.
         """
         level = self.parameter['level-of-operation']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.image_grp, n)
+                file_id = concat_padded(self.output_file_grp, n)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -127,19 +122,19 @@ class OcropyDenoise(Processor):
                                              file_id + '_' + region.id + '_' + line.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.page_grp, n)
-            file_path = os.path.join(self.page_grp, file_id + '.xml')
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,
-                file_grp=self.page_grp,
+                file_grp=self.output_file_grp,
                 pageId=input_file.pageId,
                 local_filename=file_path,
                 mimetype=MIMETYPE_PAGE,
                 content=to_xml(pcgts))
             LOG.info('created file ID: %s, file_grp: %s, path: %s',
-                     file_id, self.page_grp, out.local_filename)
+                     file_id, self.output_file_grp, out.local_filename)
 
     def process_segment(self, segment, segment_image, segment_xywh, zoom, page_id, file_id):
         LOG.info("About to despeckle '%s'", file_id)
@@ -148,9 +143,9 @@ class OcropyDenoise(Processor):
         # update METS (add the image file):
         file_path = self.workspace.save_image_file(
             bin_image,
-            file_id,
+            file_id + '.IMG-DESPECK',
             page_id=page_id,
-            file_grp=self.image_grp)
+            file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         segment.add_AlternativeImage(AlternativeImageType(
             filename=file_path,

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -25,7 +25,6 @@ from .common import (
 
 TOOL = 'ocrd-cis-ocropy-deskew'
 LOG = getLogger('processor.OcropyDeskew')
-FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-DESKEW'
 
 def deskew(pil_image, maxskew=2):
     array = pil2array(pil_image)
@@ -39,13 +38,6 @@ class OcropyDeskew(Processor):
         kwargs['ocrd_tool'] = ocrd_tool['tools'][TOOL]
         kwargs['version'] = ocrd_tool['version']
         super(OcropyDeskew, self).__init__(*args, **kwargs)
-        if hasattr(self, 'output_file_grp'):
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_FILEGRP_IMG
-                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Deskew the regions of the workspace.
@@ -59,19 +51,22 @@ class OcropyDeskew(Processor):
         the deskewing angle of the region (up to ``maxskew``). Annotate the
         angle in the region.
 
-        Add a new image file to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or ``OCR-D-IMG-DESKEW``,
-        and an ID based on input file and input element.
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-DESKEW`` along with further
+        identification of the input element.
 
         Produce a new output file by serialising the resulting hierarchy.
         """
         level = self.parameter['level-of-operation']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.image_grp, n)
+                file_id = concat_padded(self.output_file_grp, n)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -117,19 +112,19 @@ class OcropyDeskew(Processor):
                                           file_id + '_' + region.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.page_grp, n)
-            file_path = os.path.join(self.page_grp, file_id + '.xml')
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,
-                file_grp=self.page_grp,
+                file_grp=self.output_file_grp,
                 pageId=input_file.pageId,
                 local_filename=file_path,
                 mimetype=MIMETYPE_PAGE,
                 content=to_xml(pcgts))
             LOG.info('created file ID: %s, file_grp: %s, path: %s',
-                     file_id, self.page_grp, out.local_filename)
+                     file_id, self.output_file_grp, out.local_filename)
 
     def _process_segment(self, segment, segment_image, segment_coords, segment_id, page_id, file_id):
         angle0 = segment_coords['angle'] # deskewing (w.r.t. top image) already applied to segment_image
@@ -149,9 +144,9 @@ class OcropyDeskew(Processor):
         # update METS (add the image file):
         file_path = self.workspace.save_image_file(
             segment_image,
-            file_id,
+            file_id + '.IMG-DESKEW',
             page_id=page_id,
-            file_grp=self.image_grp)
+            file_grp=self.output_file_grp)
         # update PAGE (reference the image file):
         segment.add_AlternativeImage(AlternativeImageType(
             filename=file_path,

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import
 import os.path
 
 from ocrd_utils import (
-    getLogger, concat_padded,
+    getLogger,
+    make_file_id,
+    assert_file_grp_cardinality,
     rotate_image,
     MIMETYPE_PAGE
 )
@@ -58,15 +60,12 @@ class OcropyDeskew(Processor):
         Produce a new output file by serialising the resulting hierarchy.
         """
         level = self.parameter['level-of-operation']
-        assert len(self.output_file_grp.split(',')) == 1, \
-            "Expected exactly one output file group, but '%s' has %d" % (
-                self.output_file_grp, len(self.output_file_grp.split(',')))
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
+            file_id = make_file_id(input_file, self.output_file_grp)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -112,9 +111,6 @@ class OcropyDeskew(Processor):
                                           file_id + '_' + region.id)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
             file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,

--- a/ocrd_cis/ocropy/dewarp.py
+++ b/ocrd_cis/ocropy/dewarp.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import
 import os.path
 import numpy as np
 
-from ocrd_utils import getLogger, concat_padded
+from ocrd_utils import (
+    getLogger,
+    make_file_id,
+    assert_file_grp_cardinality,
+)
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import (
     MetadataItemType,
@@ -96,15 +100,12 @@ class OcropyDewarp(Processor):
 
         Produce a new output file by serialising the resulting hierarchy.
         """
-        assert len(self.output_file_grp.split(',')) == 1, \
-            "Expected exactly one output file group, but '%s' has %d" % (
-                self.output_file_grp, len(self.output_file_grp.split(',')))
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
+            file_id = make_file_id(input_file, self.output_file_grp)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -178,9 +179,6 @@ class OcropyDewarp(Processor):
                         comments=line_xywh['features'] + ',dewarped'))
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
             file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,

--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -7,7 +7,9 @@ from PIL import Image
 import Levenshtein
 
 from ocrd_utils import (
-    getLogger, concat_padded,
+    getLogger,
+    make_file_id,
+    assert_file_grp_cardinality,
     coordinates_for_segment,
     polygon_from_bbox,
     points_from_polygon,
@@ -130,6 +132,10 @@ class OcropyRecognize(Processor):
 
         Produce a new output file by serialising the resulting hierarchy.
         """
+
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
+
         # from ocropus-rpred:
         self.network = load_object(self.get_model(), verbose=1)
         for x in self.network.walk():
@@ -171,12 +177,8 @@ class OcropyRecognize(Processor):
             self.process_regions(regions, maxlevel, page_image, page_coords)
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp,
-                                            self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
-            file_path = os.path.join(self.output_file_grp,
-                                     file_id + '.xml')
+            file_id = make_file_id(input_file.ID, self.output_file_grp)
+            file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,
                 file_grp=self.output_file_grp,

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -37,7 +37,6 @@ from .common import (
 
 TOOL = 'ocrd-cis-ocropy-resegment'
 LOG = getLogger('processor.OcropyResegment')
-FALLBACK_FILEGRP_IMG = 'OCR-D-IMG-RESEG'
 
 def resegment(line_polygon, region_labels, region_bin, line_id,
               extend_margins=3,
@@ -119,13 +118,6 @@ class OcropyResegment(Processor):
         kwargs['ocrd_tool'] = self.ocrd_tool['tools'][TOOL]
         kwargs['version'] = self.ocrd_tool['version']
         super(OcropyResegment, self).__init__(*args, **kwargs)
-        if hasattr(self, 'output_file_grp'):
-            try:
-                self.page_grp, self.image_grp = self.output_file_grp.split(',')
-            except ValueError:
-                self.page_grp = self.output_file_grp
-                self.image_grp = FALLBACK_FILEGRP_IMG
-                LOG.info("No output file group for images specified, falling back to '%s'", FALLBACK_FILEGRP_IMG)
 
     def process(self):
         """Resegment lines of the workspace.
@@ -145,9 +137,9 @@ class OcropyResegment(Processor):
         outline, intersect with the old polygon, and find the contour of that
         segment. Annotate the result as new coordinates of the line.
 
-        Add a new image file to the workspace with the fileGrp USE given
-        in the second position of the output fileGrp, or ``OCR-D-IMG-RESEG``,
-        and an ID based on input file and input element.
+        Add the new image file to the workspace along with the output fileGrp,
+        and using a file ID with suffix ``.IMG-RESEG`` along with further
+        identification of the input element.
 
         Produce a new output file by serialising the resulting hierarchy.
         """
@@ -161,12 +153,15 @@ class OcropyResegment(Processor):
         # pixel density (at least if source input is not 300 DPI).
         threshold = self.parameter['min_fraction']
         margin = self.parameter['extend_margins']
+        assert len(self.output_file_grp.split(',')) == 1, \
+            "Expected exactly one output file group, but '%s' has %d" % (
+                self.output_file_grp, len(self.output_file_grp.split(',')))
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp, self.image_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.image_grp, n)
+                file_id = concat_padded(self.output_file_grp, n)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
@@ -273,25 +268,25 @@ class OcropyResegment(Processor):
                     # update METS (add the image file):
                     file_path = self.workspace.save_image_file(
                         line_image,
-                        file_id=file_id + '_' + region.id + '_' + line.id,
+                        file_id=file_id + '_' + region.id + '_' + line.id + '.IMG-RESEG',
                         page_id=page_id,
-                        file_grp=self.image_grp)
+                        file_grp=self.output_file_grp)
                     # update PAGE (reference the image file):
                     line.add_AlternativeImage(AlternativeImageType(
                         filename=file_path,
                         comments=region_xywh['features']))
 
             # update METS (add the PAGE file):
-            file_id = input_file.ID.replace(self.input_file_grp, self.page_grp)
+            file_id = input_file.ID.replace(self.input_file_grp, self.output_file_grp)
             if file_id == input_file.ID:
-                file_id = concat_padded(self.page_grp, n)
-            file_path = os.path.join(self.page_grp, file_id + '.xml')
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             out = self.workspace.add_file(
                 ID=file_id,
-                file_grp=self.page_grp,
+                file_grp=self.output_file_grp,
                 pageId=input_file.pageId,
                 local_filename=file_path,
                 mimetype=MIMETYPE_PAGE,
                 content=to_xml(pcgts))
             LOG.info('created file ID: %s, file_grp: %s, path: %s',
-                     file_id, self.page_grp, out.local_filename)
+                     file_id, self.output_file_grp, out.local_filename)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -33,7 +33,8 @@ from ocrd_models.ocrd_page_generateds import (
 from ocrd import Processor
 from ocrd_utils import (
     getLogger,
-    concat_padded,
+    make_file_id,
+    assert_file_grp_cardinality,
     coordinates_of_segment,
     coordinates_for_segment,
     points_from_polygon,
@@ -204,16 +205,13 @@ class OcropySegment(Processor):
         overwrite_separators = self.parameter['overwrite_separators']
         overwrite_order = self.parameter['overwrite_order']
         oplevel = self.parameter['level-of-operation']
-        assert len(self.output_file_grp.split(',')) == 1, \
-            "Expected exactly one output file group, but '%s' has %d" % (
-                self.output_file_grp, len(self.output_file_grp.split(',')))
+
+        assert_file_grp_cardinality(self.input_file_grp, 1)
+        assert_file_grp_cardinality(self.output_file_grp, 1)
 
         for (n, input_file) in enumerate(self.input_files):
             LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
-            file_id = input_file.ID.replace(self.input_file_grp,
-                                            self.output_file_grp)
-            if file_id == input_file.ID:
-                file_id = concat_padded(self.output_file_grp, n)
+            file_id = make_file_id(input_file, self.output_file_grp)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)


### PR DESCRIPTION
This is the continuation of #57 I have no rights to push there.

Replaces the `file_id` logic with `make_file_id` and adds `assert_file_grp_cardinality` checks for input and output file group.