### PR TITLE
resegment: skip empty line polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,14 +228,25 @@ ocrd-cis-ocropy-resegment \
 
 Available parameters are:
 ```sh
-   "dpi" [number - -1]
+   "level-of-operation" [string - "page"]
+    PAGE XML hierarchy level to segment textlines in ('region' abides by
+    existing text region boundaries, 'page' optimises lines in the whole
+    page once
+    Possible values: ["page", "region"]
+   "method" [string - "lineest"]
+    source for new line polygon candidates ('lineest' for line
+    estimation, i.e. how Ocropy would have segmented text lines;
+    'baseline' tries to re-polygonize from the baseline annotation;
+    'ccomps' avoids crossing connected components by majority rule)
+    Possible values: ["lineest", "baseline", "ccomps"]
+   "dpi" [number - 0]
     pixel density in dots per inch (overrides any meta-data in the
-    images); disabled when negative
-   "min_fraction" [number - 0.8]
-    share of foreground pixels that must be retained by the largest label
+    images); disabled when zero or negative
+   "min_fraction" [number - 0.75]
+    share of foreground pixels that must be retained by the output
+    polygons
    "extend_margins" [number - 3]
-    number of pixels to extend the input polygons horizontally and
-    vertically before intersecting
+    number of pixels to extend the input polygons in all directions
 ```
 
 ### ocrd-cis-ocropy-segment

--- a/ocrd_cis/align/cli.py
+++ b/ocrd_cis/align/cli.py
@@ -97,14 +97,14 @@ class Aligner(Processor):
                 te = TextEquivType(
                     Unicode=get_textequiv_unicode(line.region),
                     conf=get_textequiv_conf(line.region),
-                    dataType="ocrd-cis-line-alignment",
-                    dataTypeDetails=ddt)
+                    dataType="other",
+                    dataTypeDetails="ocrd-cis-line-alignment:" + ddt)
                 lines[0].region.add_TextEquiv(te)
             else:
                 self.log.debug("len: %i, i: %i", len(lines[0].region.get_TextEquiv()), i)
-                lines[0].region.get_TextEquiv()[i].set_dataType(
-                    "ocrd-cis-line-alignment-master-ocr")
-            lines[0].region.get_TextEquiv()[i].set_dataTypeDetails(ddt)
+                lines[0].region.get_TextEquiv()[i].set_dataType("other")
+                lines[0].region.get_TextEquiv()[i].set_dataTypeDetails(
+                    "ocrd-cis-line-alignment-master-ocr:" + ddt)
             lines[0].region.get_TextEquiv()[i].set_index(i+1)
         self.align_words(lines)
 
@@ -146,8 +146,8 @@ class Aligner(Processor):
                 ifg = word.input_file.input_file_group
                 self.log.debug("(empty) word alignment: [%s]", ifg)
                 te = TextEquivType(
-                    dataType="ocrd-cis-empty-word-alginment",
-                    dataTypeDetails=ifg)
+                    dataType="other",
+                    dataTypeDetails="ocrd-cis-empty-word-alignment:" + ifg)
                 words[0].region[0].add_TextEquiv(te)
                 words[0].region[0].get_TextEquiv()[i].set_index(i+1)
                 continue
@@ -162,13 +162,13 @@ class Aligner(Processor):
                 te = TextEquivType(
                     Unicode=_str,
                     conf=conf,
-                    dataType="ocrd-cis-word-alignment",
-                    dataTypeDetails=ddt)
+                    dataType="other",
+                    dataTypeDetails="ocrd-cis-word-alignment:" + ddt)
                 words[0].region[0].add_TextEquiv(te)
             else:
-                words[0].region[0].get_TextEquiv()[i].set_dataType(
-                    'ocrd-cis-word-alignment-master-ocr')
-                words[0].region[0].get_TextEquiv()[i].set_dataTypeDetails(ddt)
+                words[0].region[0].get_TextEquiv()[i].set_dataType("other")
+                words[0].region[0].get_TextEquiv()[i].set_dataTypeDetails(
+                    "ocrd-cis-word-alignment-master-ocr:" + ddt)
             words[0].region[0].get_TextEquiv()[i].set_index(i+1)
 
     def find_word(self, tokens, regions, t="other"):

--- a/ocrd_cis/align/cli.py
+++ b/ocrd_cis/align/cli.py
@@ -8,6 +8,7 @@ from ocrd.decorators import ocrd_cli_options
 from ocrd.decorators import ocrd_cli_wrap_processor
 from ocrd_utils import MIMETYPE_PAGE
 from ocrd_utils import getLogger
+from ocrd_utils import getLevelName
 from ocrd_utils import make_file_id
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import to_xml
@@ -15,18 +16,12 @@ from ocrd_models.ocrd_page_generateds import TextEquivType
 from ocrd_cis import JavaAligner
 from ocrd_cis import get_ocrd_tool
 
-LOG_LEVEL = 'INFO'
-
 @click.command()
 @ocrd_cli_options
 def ocrd_cis_align(*args, **kwargs):
-    if 'log_level' in kwargs and kwargs['log_level']:
-        global LOG_LEVEL
-        LOG_LEVEL = kwargs['log_level']
     return ocrd_cli_wrap_processor(Aligner, *args, **kwargs)
 
 class Aligner(Processor):
-    LOG_LEVEL = 'INFO'
     def __init__(self, *args, **kwargs):
         ocrd_tool = get_ocrd_tool()
         kwargs['ocrd_tool'] = ocrd_tool['tools']['ocrd-cis-align']
@@ -294,7 +289,7 @@ class Aligner(Processor):
             self.log.debug("input line: %s", i)
         n = len(ifs)
         self.log.debug("starting java client")
-        p = JavaAligner(n, LOG_LEVEL or 'INFO')
+        p = JavaAligner(n, getLevelName(self.log.getEffectiveLevel()))
         return p.run("\n".join(_input))
 
 class FileAlignment:

--- a/ocrd_cis/align/cli.py
+++ b/ocrd_cis/align/cli.py
@@ -32,7 +32,9 @@ class Aligner(Processor):
         kwargs['ocrd_tool'] = ocrd_tool['tools']['ocrd-cis-align']
         kwargs['version'] = ocrd_tool['version']
         super(Aligner, self).__init__(*args, **kwargs)
-        self.log = getLogger('cis.Processor.Aligner')
+
+        if hasattr(self, 'workspace'):
+            self.log = getLogger('cis.Processor.Aligner')
 
     def process(self):
         ifgs = self.input_file_grp.split(",")  # input file groups

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -191,13 +191,19 @@
 			"output_file_grp": [
 				"OCR-D-SEG-LINE"
 			],
-			"description": "Resegment lines with ocropy (by shrinking annotated polygons)",
+			"description": "Resegment text lines",
 			"parameters": {
 				"level-of-operation": {
 					"type": "string",
 					"enum": ["page", "region"],
-					"description": "PAGE XML hierarchy level granularity to segment lines in",
+					"description": "PAGE XML hierarchy level to segment textlines in ('region' abides by existing text region boundaries, 'page' optimises lines in the whole page once",
 					"default": "page"
+				},
+				"method": {
+					"type": "string",
+					"enum": ["lineest", "baseline", "ccomps"],
+					"description": "source for new line polygon candidates ('lineest' for line estimation, i.e. how Ocropy would have segmented text lines; 'baseline' tries to re-polygonize from the baseline annotation; 'ccomps' avoids crossing connected components by majority rule)",
+					"default": "lineest"
 				},
 				"dpi": {
 					"type": "number",
@@ -208,13 +214,13 @@
 				"min_fraction": {
 					"type": "number",
 					"format": "float",
-					"description": "share of foreground pixels that must be retained by the largest label",
+					"description": "share of foreground pixels that must be retained by the output polygons",
 					"default": 0.75
 				},
 				"extend_margins": {
 					"type": "number",
 					"format": "integer",
-					"description": "number of pixels to extend the input polygons horizontally and vertically before intersecting",
+					"description": "number of pixels to extend the input polygons in all directions",
 					"default": 3
 				}
 			}

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -238,8 +238,14 @@
 				"range": {
 					"type": "number",
 					"format": "float",
-					"description": "maximum vertical disposition or maximum margin (will be multiplied by mean centerline deltas to yield pixels)",
+					"description": "maximum vertical disposition or maximum margin (will be multiplied by mean centerline deltas to yield pixels); also the mean vertical padding",
 					"default": 4.0
+				},
+				"smoothness": {
+					"type": "number",
+					"format": "float",
+					"description": "kernel size (relative to image height) of horizontal blur applied to foreground to find the center line; the smaller the more dynamic (0.1 would be a better default)",
+					"default": 1.0
 				},
 				"max_neighbour": {
 					"type": "number",

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -193,6 +193,12 @@
 			],
 			"description": "Resegment lines with ocropy (by shrinking annotated polygons)",
 			"parameters": {
+				"level-of-operation": {
+					"type": "string",
+					"enum": ["page", "region"],
+					"description": "PAGE XML hierarchy level granularity to segment lines in",
+					"default": "page"
+				},
 				"dpi": {
 					"type": "number",
 					"format": "float",
@@ -203,7 +209,7 @@
 					"type": "number",
 					"format": "float",
 					"description": "share of foreground pixels that must be retained by the largest label",
-					"default": 0.8
+					"default": 0.75
 				},
 				"extend_margins": {
 					"type": "number",

--- a/ocrd_cis/ocropy/binarize.py
+++ b/ocrd_cis/ocropy/binarize.py
@@ -175,6 +175,9 @@ class OcropyBinarize(Processor):
                              file_id, self.output_file_grp, out.local_filename)
 
     def process_page(self, page, page_image, page_xywh, zoom, page_id, file_id):
+        if not page_image.width or not page_image.height:
+            self.logger.warning("Skipping page '%s' with zero size", page_id)
+            return
         self.logger.info("About to binarize page '%s'", page_id)
         features = page_xywh['features']
         if 'angle' in page_xywh and page_xywh['angle']:
@@ -220,6 +223,9 @@ class OcropyBinarize(Processor):
             comments=features))
 
     def process_region(self, region, region_image, region_xywh, zoom, page_id, file_id):
+        if not region_image.width or not region_image.height:
+            self.logger.warning("Skipping region '%s' with zero size", region.id)
+            return
         self.logger.info("About to binarize page '%s' region '%s'", page_id, region.id)
         features = region_xywh['features']
         if 'angle' in region_xywh and region_xywh['angle']:
@@ -267,6 +273,9 @@ class OcropyBinarize(Processor):
             comments=features))
 
     def process_line(self, line, line_image, line_xywh, zoom, page_id, region_id, file_id):
+        if not line_image.width or not line_image.height:
+            self.logger.warning("Skipping line '%s' with zero size", line.id)
+            return
         self.logger.info("About to binarize page '%s' region '%s' line '%s'",
                          page_id, region_id, line.id)
         features = line_xywh['features']

--- a/ocrd_cis/ocropy/binarize.py
+++ b/ocrd_cis/ocropy/binarize.py
@@ -140,7 +140,7 @@ class OcropyBinarize(Processor):
                 if level == 'table':
                     regions = page.get_TableRegion()
                 else: # region
-                    regions = page.get_AllRegions(classes=['Text'])
+                    regions = page.get_AllRegions(classes=['Text'], order='reading-order')
                 if not regions:
                     self.logger.warning('Page "%s" contains no text regions', page_id)
                 for region in regions:

--- a/ocrd_cis/ocropy/clip.py
+++ b/ocrd_cis/ocropy/clip.py
@@ -103,6 +103,7 @@ class OcropyClip(Processor):
             else:
                 zoom = 1
 
+            # FIXME: what about text regions inside table regions?
             regions = list(page.get_TextRegion())
             num_texts = len(regions)
             regions += (
@@ -241,6 +242,10 @@ class OcropyClip(Processor):
                 continue
             LOG.debug('segment "%s" vs neighbour "%s": suppressing %d pixels on page "%s"',
                       segment.id, neighbour.id, np.count_nonzero(intruders), page_id)
+            # suppress in segment_mask so these intruders can stay in the neighbours
+            # (are not removed from both sides)
+            segment_mask -= intruders
+            # suppress in derived image result to be annotated
             clip_mask = array2pil(intruders)
             segment_image.paste(background_image, mask=clip_mask) # suppress in raw image
             if segment_image.mode in ['RGB', 'L', 'RGBA', 'LA']:

--- a/ocrd_cis/ocropy/clip.py
+++ b/ocrd_cis/ocropy/clip.py
@@ -240,8 +240,8 @@ class OcropyClip(Processor):
             num_foreground = np.count_nonzero(segment_mask * parent_bin)
             if not num_intruders:
                 continue
-            LOG.debug('segment "%s" vs neighbour "%s": suppressing %d pixels on page "%s"',
-                      segment.id, neighbour.id, np.count_nonzero(intruders), page_id)
+            LOG.debug('segment "%s" vs neighbour "%s": suppressing %d of %d pixels on page "%s"',
+                      segment.id, neighbour.id, num_intruders, num_foreground, page_id)
             # suppress in segment_mask so these intruders can stay in the neighbours
             # (are not removed from both sides)
             segment_mask -= intruders

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -536,8 +536,8 @@ def compute_hlines(binary, scale,
     ## with zero horizontal dilation, hlines would need
     ## to be perfectly contiguous (i.e. without noise
     ## from binarization):
-    d1 = odd(max(1,scale/8))
-    d0 = odd(max(1,scale/4))
+    d0 = odd(max(1,scale/8))
+    d1 = odd(max(1,scale/4))
     # TODO This does not cope well with slightly sloped or heavily fragmented lines
     horiz = binary
     # 1- close horizontally a little to make warped or

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -488,8 +488,9 @@ def compute_images(binary, scale, maximages=5):
     # 4- reconstruct the losses up to a certain distance
     #    to avoid creeping into pure h/v-lines again but still
     #    cover most of the large object
-    images = np.where(images, closed, 2)
-    images = morph.spread_labels(images, maxdist=scale) % 2 | closed
+    #images = np.where(images, closed, 2)
+    #images = morph.spread_labels(images, maxdist=scale) % 2 | closed
+    images = morph.rb_reconstruction(closed, images, step=2, maxsteps=scale)
     DSAVE('images4_reconstructed', images+0.6*binary)
     # 5- select nbest
     images = morph.select_regions(images,sl.area,min=(4*scale)**2,nbest=maximages)
@@ -552,8 +553,9 @@ def compute_hlines(binary, scale,
     #    cover most of the line even if not perfectly horizontal
     # (it would be fantastic if we could calculate the
     #  distance transform with stronger horizontal weights)
-    horiz = np.where(horiz, opened, 2)
-    horiz = morph.spread_labels(horiz, maxdist=d1) % 2 | opened
+    #horiz = np.where(horiz, opened, 2)
+    #horiz = morph.spread_labels(horiz, maxdist=d1) % 2 | opened
+    horiz = morph.rb_reconstruction(opened, horiz, step=2, maxsteps=d1//2)
     DSAVE('hlines3_reconstructed', horiz+0.6*binary)
     if not horiz.any():
         return horiz > 0
@@ -620,8 +622,9 @@ def compute_separators_morph(binary, scale,
     #    cover most of the line even if not perfectly vertical
     # (it would be fantastic if we could calculate the
     #  distance transform with stronger vertical weights)
-    vert = np.where(vert, opened, 2)
-    vert = morph.spread_labels(vert, maxdist=d1) % 2 | opened
+    #vert = np.where(vert, opened, 2)
+    #vert = morph.spread_labels(vert, maxdist=d1) % 2 | opened
+    vert = morph.rb_reconstruction(opened, vert, step=2, maxsteps=d1//2)
     DSAVE('colseps3_reconstructed', vert+0.6*binary)
     if not vert.any():
         return vert > 0

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1114,6 +1114,12 @@ def compute_segmentation(binary,
     llabels2 = morph.propagate_labels(binary, seeds, conflict=0)
     conflicts = llabels > llabels2
     llabels = np.where(conflicts, seeds, llabels)
+    # capture diacritics (isolated components above seeds)
+    seeds2 = interpolation.shift(seeds, (-scale, 0), order=0, prefilter=False)
+    seeds2 = np.where(seeds, seeds, seeds2)
+    DSAVE('lineseeds_cap', [seeds2,binary])
+    llabels2 = morph.propagate_labels_simple(binary, seeds2)
+    llabels = np.where(llabels, llabels, llabels2)
     # (protect sepmask as a temporary label)
     seplabel = np.max(seeds)+1
     llabels[sepmask>0] = seplabel

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1011,8 +1011,9 @@ def compute_segmentation(binary,
         hlines = np.zeros_like(binary, np.bool)
         vlines = np.zeros_like(binary, np.bool)
         images = np.zeros_like(binary, np.bool)
-    if seps is not None:
+    if seps is not None and not seps.all():
         # suppress separators/images for line estimation
+        # (unless it encompasses the full image for some reason)
         binary = (1-seps) * binary
 
     LOG.debug('computing gradient map')

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1330,7 +1330,7 @@ def lines2regions(binary, llabels,
                         if debug:
                             LOG.debug('new region {} for existing region {} lines {}'.format(num_regions, region, lines))
                         else:
-                            LOG.debug('new region %d for existing region {}', num_regions, region)
+                            LOG.debug('new region %d for existing region %d', num_regions, region)
                     relabel[lines] = num_regions
         
         _, lcounts = np.unique(lbin, return_counts=True)

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -955,7 +955,9 @@ def compute_segmentation(binary,
     Given a binarized (and inverted) image as Numpy array ``image``, compute
     a complete segmentation of it into text lines as a label array.
 
-    If ``fullpage`` is false, then avoid single-line horizontal splits.
+    If ``fullpage`` is false, then
+    - avoid single-line horizontal splits, and
+    - ignore any foreground in ``seps``.
 
     If ``fullpage`` is true, then
     - allow all horizontal splits, and search
@@ -1005,13 +1007,13 @@ def compute_segmentation(binary,
         binary = np.minimum(binary,1-hlines)
         binary = np.minimum(binary,1-vlines)
         binary = np.minimum(binary,1-images)
-        if seps is not None:
-            # suppress separators/images for line estimation
-            binary = (1-seps) * binary
     else:
         hlines = np.zeros_like(binary, np.bool)
         vlines = np.zeros_like(binary, np.bool)
         images = np.zeros_like(binary, np.bool)
+    if seps is not None:
+        # suppress separators/images for line estimation
+        binary = (1-seps) * binary
 
     LOG.debug('computing gradient map')
     bottom, top, boxmap = compute_gradmaps(binary, scale,

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1337,8 +1337,8 @@ def lines2regions(binary, llabels,
                         linelabels[0] = 0 # without bg
                         # get significant line labels for this partition
                         # (but keep insignificant non-empty labels when complete)
-                        linelabels = np.nonzero(linelabels >= np.minimum(
-                            np.maximum(bincounts, 1), min_line * scale))[0]
+                        linelabels = np.nonzero(linelabels >= min(max(1, bincounts.max()),
+                                                                  min_line * scale))[0]
                         if np.any(linelabels):
                             lpartitions.append(linelabels)
                             if debug: LOG.debug('  sepmask partition %d: %s', label, str(linelabels))

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1279,12 +1279,12 @@ def lines2regions(binary, llabels,
         sepmask = 1-morph.keep_marked(1-sepmask, lbinary>0)
         DSAVE('sepmask', [sepmask,binary])
     objects = [None] + morph.find_objects(llabels)
-    #centers = measurements.center_of_mass(binary, llabels, np.unique(llabels))
-    def center(obj):
-        if morph.sl.empty(obj):
-            return [0,0]
-        return morph.sl.center(obj)
-    centers = list(map(center, objects[1:]))
+    # centers = measurements.center_of_mass(binary, llabels, np.unique(llabels))
+    # def center(obj):
+    #     if morph.sl.empty(obj):
+    #         return [0,0]
+    #     return morph.sl.center(obj)
+    # centers = list(map(center, objects[1:]))
     if scale is None:
         scale = psegutils.estimate_scale(binary, zoom)
     bincounts = np.bincount(lbinary.flatten())
@@ -1448,7 +1448,7 @@ def lines2regions(binary, llabels,
                     seplab, nseps = morph.label(sepm)
                     if nseps == 0:
                         return
-                    sepind = np.unique(seplab)
+                    # sepind = np.unique(seplab)
                     # (but keep only those with large fg i.e. ignore white-space seps)
                     seplabs, counts = np.unique(seplab * bin, return_counts=True)
                     kept = np.in1d(seplab.ravel(), seplabs[counts > scale * min_line])

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -460,6 +460,8 @@ def compute_images(binary, scale, maximages=5):
     
     Returns a same-size bool array as a mask image.
     """
+    if maximages == 0:
+        return binary == -1
     images = binary
     # d0 = odd(max(2,scale/5))
     # d1 = odd(max(2,scale/8))
@@ -599,6 +601,8 @@ def compute_separators_morph(binary, scale,
     
     Returns a same-size bool array as separator mask.
     """
+    if maxseps == 0:
+        return binary == -1
     LOG.debug("considering at most %g black column separators", maxseps)
     ## no large vertical dilation here, because
     ## that would turn letters into lines; but
@@ -663,6 +667,8 @@ def compute_colseps_conv(binary, scale=1.0, csminheight=10, maxcolseps=2):
     
     Returns a same-size bool array as separator mask.
     """
+    if maxcolseps == 0:
+        return binary == -1
     LOG.debug("considering at most %g whitespace column separators", maxcolseps)
     # find vertical whitespace by thresholding
     smoothed = filters.gaussian_filter(1.0*binary,(scale,scale*0.5))

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -546,7 +546,7 @@ def compute_hlines(binary, scale,
     DSAVE('hlines1_h-closed', horiz+0.6*binary)
     # 2- open horizontally to remove everything
     #    that is horizontally non-contiguous:
-    opened = morph.rb_opening(horiz, (1,hlminwidth*scale))
+    opened = morph.rb_opening(horiz, (1, hlminwidth*scale//2))
     DSAVE('hlines2_h-opened', opened+0.6*binary)
     # 3- reconstruct the losses up to a certain distance
     #    to avoid creeping into overlapping glyphs but still
@@ -615,7 +615,7 @@ def compute_separators_morph(binary, scale,
     DSAVE('colseps1_v-closed', vert+0.6*binary)
     # 2- open vertically to remove everything that
     #    is vertically non-contiguous:
-    opened = morph.rb_opening(vert, (csminheight*scale,1))
+    opened = morph.rb_opening(vert, (csminheight*scale//2, 1))
     DSAVE('colseps2_v-opened', opened+0.6*binary)
     # 3- reconstruct the losses up to a certain distance
     #    to avoid creeping into overlapping glyphs but still

--- a/ocrd_cis/ocropy/denoise.py
+++ b/ocrd_cis/ocropy/denoise.py
@@ -119,6 +119,9 @@ class OcropyDenoise(Processor):
 
     def process_segment(self, segment, segment_image, segment_xywh, zoom, page_id, file_id):
         LOG = getLogger('processor.OcropyDenoise')
+        if not segment_image.width or not segment_image.height:
+            LOG.warning("Skipping '%s' with zero size", file_id)
+            return
         LOG.info("About to despeckle '%s'", file_id)
         bin_image = remove_noise(segment_image,
                                  maxsize=self.parameter['noise_maxsize']/zoom*300/72) # in pt

--- a/ocrd_cis/ocropy/denoise.py
+++ b/ocrd_cis/ocropy/denoise.py
@@ -82,7 +82,7 @@ class OcropyDenoise(Processor):
                 self.process_segment(page, page_image, page_xywh, zoom,
                                      input_file.pageId, file_id)
             else:
-                regions = page.get_AllRegions(classes=['Text'])
+                regions = page.get_AllRegions(classes=['Text'], order='reading-order')
                 if not regions:
                     LOG.warning('Page "%s" contains no text regions', page_id)
                 for region in regions:

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -84,7 +84,7 @@ class OcropyDeskew(Processor):
                 if level == 'table':
                     regions = page.get_TableRegion()
                 else: # region
-                    regions = page.get_AllRegions(classes=['Text'])
+                    regions = page.get_AllRegions(classes=['Text'], order='reading-order')
                 if not regions:
                     LOG.warning('Page "%s" contains no text regions', page_id)
                 for region in regions:

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -6,7 +6,6 @@ from ocrd_utils import (
     getLogger,
     make_file_id,
     assert_file_grp_cardinality,
-    rotate_image,
     MIMETYPE_PAGE
 )
 from ocrd_modelfactory import page_from_file

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -114,6 +114,9 @@ class OcropyDeskew(Processor):
 
     def _process_segment(self, segment, segment_image, segment_coords, segment_id, page_id, file_id):
         LOG = getLogger('processor.OcropyDeskew')
+        if not segment_image.width or not segment_image.height:
+            LOG.warning("Skipping %s with zero size", segment_id)
+            return
         angle0 = segment_coords['angle'] # deskewing (w.r.t. top image) already applied to segment_image
         LOG.info("About to deskew %s", segment_id)
         angle = deskew(segment_image, maxskew=self.parameter['maxskew']) # additional angle to be applied

--- a/ocrd_cis/ocropy/dewarp.py
+++ b/ocrd_cis/ocropy/dewarp.py
@@ -81,8 +81,14 @@ class OcropyDewarp(Processor):
     
     def setup(self):
         # defaults from ocrolib.lineest:
-        range_ = self.parameter['range']
-        self.lnorm = lineest.CenterNormalizer(params=(range_, 1.0, 0.3))
+        self.lnorm = lineest.CenterNormalizer(
+            params=(self.parameter['range'],
+                    self.parameter['smoothness'],
+                    # let's not expose this for now
+                    # (otherwise we must explain mutual
+                    #  dependency between smoothness
+                    #  and extra params)
+                    0.3))
         self.logger = getLogger('processor.OcropyDewarp')
 
     def process(self):

--- a/ocrd_cis/ocropy/dewarp.py
+++ b/ocrd_cis/ocropy/dewarp.py
@@ -135,7 +135,7 @@ class OcropyDewarp(Processor):
             else:
                 zoom = 1
 
-            regions = page.get_AllRegions(classes=['Text'])
+            regions = page.get_AllRegions(classes=['Text'], order='reading-order')
             if not regions:
                 self.logger.warning('Page "%s" contains no text regions', page_id)
             for region in regions:

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -23,7 +23,7 @@ def label(image,**kw):
     """
     n, labels = cv2.connectedComponents(image.astype(uint8))
     #n, labels = cv2.connectedComponentsWithAlgorithm(image.astype(uint8), connectivity=4, ltype=2, ccltype=cv2.CCL_DEFAULT)
-    return labels, n
+    return labels, n-1
     # try: return measurements.label(image,**kw)
     # except: pass
     # types = ["int32","uint32","int64","uint64","int16","uint16"]

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -19,7 +19,9 @@ def label(image,**kw):
     - same-size Numpy array with integer labels for fg components
     - number of components (eq. largest label)
     """
-    n, labels = cv2.connectedComponents(image.astype(uint8))
+    # default connectivity in OpenCV: 8 (which is equivalent to...)
+    # default connectivity in scikit-image: 2
+    n, labels = cv2.connectedComponents(image.astype(uint8), connectivity=4)
     #n, labels = cv2.connectedComponentsWithAlgorithm(image.astype(uint8), connectivity=4, ltype=2, ccltype=cv2.CCL_DEFAULT)
     return labels, n-1
     # try: return measurements.label(image,**kw)

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -125,6 +125,20 @@ def rb_closing(image,size,origin=0):
     # image = rb_dilation(image,size,origin=0)
     # return rb_erosion(image,size,origin=-1)
 
+@checks(ABINARY2,ABINARY2)
+def rb_reconstruction(image,mask,step=1,maxsteps=None):
+    kernel = cv2.getStructuringElement(cv2.MORPH_CROSS, (2*step+1,2*step+1))
+    dilated = image.astype(uint8)
+    while maxsteps is None or maxsteps > 0:
+        dilated = cv2.dilate(src=dilated, kernel=kernel)
+        cv2.bitwise_and(src1=dilated, src2=mask.astype(uint8), dst=dilated)
+        # did result change?
+        if (image == dilated).all():
+            return dilated
+        if maxsteps:
+            maxsteps -= step
+    return dilated
+    
 @checks(GRAYSCALE,uintpair)
 def rg_dilation(image,size,origin=0):
     """Grayscale dilation using fast OpenCV.dilate."""

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -188,6 +188,8 @@ def spread_labels(labels,maxdist=9999999):
     #distances,features = morphology.distance_transform_edt(labels==0,return_distances=1,return_indices=1)
     #indexes = features[0]*labels.shape[1]+features[1]
     #spread = labels.ravel()[indexes.ravel()].reshape(*labels.shape)
+    if not labels.any():
+        return labels
     distances,indexes = cv2.distanceTransformWithLabels(array(labels==0,uint8),cv2.DIST_L2,cv2.DIST_MASK_PRECISE,labelType=cv2.DIST_LABEL_PIXEL)
     spread = labels[where(labels>0)][indexes-1]
     spread *= (distances<maxdist)

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -293,7 +293,7 @@ def select_regions(binary,f,min=0,nbest=100000):
     if binary.max() == 1:
         labels,_ = label(binary)
     else:
-        labels = binary
+        labels = binary.astype(uint8)
     objects = find_objects(labels)
     scores = [f(o) for o in objects]
     best = argsort(scores)

--- a/ocrd_cis/ocropy/ocrolib/morph.py
+++ b/ocrd_cis/ocropy/ocrolib/morph.py
@@ -2,8 +2,6 @@
 ### various add-ons to the SciPy morphology package
 ################################################################
 
-
-
 from numpy import *
 #from scipy.ndimage import morphology,measurements,filters
 from scipy.ndimage import measurements
@@ -68,36 +66,40 @@ def check_binary(image):
     assert amin(image)>=0 and amax(image)<=1,\
         "array should be binary, has values %g to %g"%(amin(image),amax(image))
 
+@checks(uintpair)
+def brick(size):
+    return ones(size, uint8)
+
 @checks(ABINARY2,uintpair)
 def r_dilation(image,size,origin=0):
     """Dilation with rectangular structuring element using fast OpenCV.dilate."""
-    return cv2.dilate(image.astype(uint8), ones(size, uint8))
+    return cv2.dilate(image.astype(uint8), brick(size))
     # return filters.maximum_filter(image,size,origin=(size[0]%2-1,size[1]%2-1))
 
 @checks(ABINARY2,uintpair)
 def r_erosion(image,size,origin=-1):
     """Erosion with rectangular structuring element using fast OpenCV.erode."""
-    return cv2.erode(image.astype(uint8), ones(size, uint8))
+    return cv2.erode(image.astype(uint8), brick(size))
     # return filters.minimum_filter(image,size,origin=0, mode='constant', cval=1)
 
 @checks(ABINARY2,uintpair)
 def r_opening(image,size,origin=0):
     """Opening with rectangular structuring element using fast OpenCV.morphologyEx."""
-    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_OPEN, ones(size, uint8))
+    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_OPEN, brick(size))
     # image = r_erosion(image,size,origin=0)
     # return r_dilation(image,size,origin=-1)
 
 @checks(ABINARY2,uintpair)
 def r_closing(image,size,origin=0):
     """Closing with rectangular structuring element using fast OpenCV.morphologyEx."""
-    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_CLOSE, ones(size, uint8))
+    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_CLOSE, brick(size))
     # image = r_dilation(image,size,origin=0)
     # return r_erosion(image,size,origin=-1)
 
 @checks(ABINARY2,uintpair)
 def rb_dilation(image,size,origin=0):
     """Binary dilation using linear filters."""
-    return cv2.dilate(image.astype(uint8), ones(size, uint8))
+    return cv2.dilate(image.astype(uint8), brick(size))
     # output = zeros(image.shape,'f')
     # filters.uniform_filter(image,size,output=output,origin=(size[0]%2-1,size[1]%2-1))
     # # 0 creates rounding artifacts
@@ -106,7 +108,7 @@ def rb_dilation(image,size,origin=0):
 @checks(ABINARY2,uintpair)
 def rb_erosion(image,size,origin=-1):
     """Binary erosion using linear filters."""
-    return cv2.erode(image.astype(uint8), ones(size, uint8))
+    return cv2.erode(image.astype(uint8), brick(size))
     # output = zeros(image.shape,'f')
     # filters.uniform_filter(image,size,output=output,origin=0, mode='constant', cval=1)
     # return array(output==1,'i')
@@ -114,14 +116,14 @@ def rb_erosion(image,size,origin=-1):
 @checks(ABINARY2,uintpair)
 def rb_opening(image,size,origin=0):
     """Binary opening using linear filters."""
-    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_OPEN, ones(size, uint8))
+    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_OPEN, brick(size))
     # image = rb_erosion(image,size,origin=0)
     # return rb_dilation(image,size,origin=-1)
 
 @checks(ABINARY2,uintpair)
 def rb_closing(image,size,origin=0):
     """Binary closing using linear filters."""
-    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_CLOSE, ones(size, uint8))
+    return cv2.morphologyEx(image.astype(uint8), cv2.MORPH_CLOSE, brick(size))
     # image = rb_dilation(image,size,origin=0)
     # return rb_erosion(image,size,origin=-1)
 
@@ -142,26 +144,26 @@ def rb_reconstruction(image,mask,step=1,maxsteps=None):
 @checks(GRAYSCALE,uintpair)
 def rg_dilation(image,size,origin=0):
     """Grayscale dilation using fast OpenCV.dilate."""
-    return cv2.dilate(image, ones(size, uint8))
+    return cv2.dilate(image, brick(size))
     # return filters.maximum_filter(image,size,origin=origin)
 
 @checks(GRAYSCALE,uintpair)
 def rg_erosion(image,size,origin=0):
     """Grayscale erosion using fast OpenCV.erode."""
-    return cv2.erode(image, ones(size, uint8))
+    return cv2.erode(image, brick(size))
     # return filters.minimum_filter(image,size,origin=origin, mode='constant', cval=1)
 
 @checks(GRAYSCALE,uintpair)
 def rg_opening(image,size,origin=0):
     """Grayscale opening using fast OpenCV.morphologyEx."""
-    return cv2.morphologyEx(image, cv2.MORPH_OPEN, ones(size, uint8))
+    return cv2.morphologyEx(image, cv2.MORPH_OPEN, brick(size))
     # image = r_erosion(image,size,origin=origin)
     # return r_dilation(image,size,origin=origin)
 
 @checks(GRAYSCALE,uintpair)
 def rg_closing(image,size,origin=0):
     """Grayscale closing using fast OpenCV.morphologyEx."""
-    return cv2.morphologyEx(image, cv2.MORPH_CLOSE, ones(size, uint8))
+    return cv2.morphologyEx(image, cv2.MORPH_CLOSE, brick(size))
     # image = r_dilation(image,size,origin=0)
     # return r_erosion(image,size,origin=-1)
 
@@ -196,7 +198,7 @@ def find_label_contours(labels):
         contours[label] = find_contours(labels==label)
     return contours
 
-@checks(SEGMENTATION)
+@checks(ALL(SEGMENTATION,ANONNEG))
 def spread_labels(labels,maxdist=9999999):
     """Spread the given labels to the background."""
     #distances,features = morphology.distance_transform_edt(labels==0,return_distances=1,return_indices=1)
@@ -206,8 +208,20 @@ def spread_labels(labels,maxdist=9999999):
         return labels
     distances,indexes = cv2.distanceTransformWithLabels(array(labels==0,uint8),cv2.DIST_L2,cv2.DIST_MASK_PRECISE,labelType=cv2.DIST_LABEL_PIXEL)
     spread = labels[where(labels>0)][indexes-1]
+    if maxdist is None:
+        return spread, distances
     spread *= (distances<maxdist)
     return spread
+
+@checks(SEGMENTATION)
+def dist_labels(labels):
+    """Get the distance transformation of the segments."""
+    if not labels.any():
+        return labels
+    return cv2.distanceTransform(labels,
+                                 distanceType=cv2.DIST_L1,
+                                 maskSize=3,
+                                 dstType=cv2.CV_8U)
 
 @checks(ABINARY2,ABINARY2)
 def keep_marked(image,markers):

--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -164,7 +164,7 @@ class OcropyRecognize(Processor):
             self.process_regions(regions, maxlevel, page_image, page_coords)
 
             # update METS (add the PAGE file):
-            file_id = make_file_id(input_file.ID, self.output_file_grp)
+            file_id = make_file_id(input_file, self.output_file_grp)
             file_path = os.path.join(self.output_file_grp, file_id + '.xml')
             pcgts.set_pcGtsId(file_id)
             out = self.workspace.add_file(

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -257,7 +257,7 @@ class OcropyResegment(Processor):
                     file_path = self.workspace.save_image_file(
                         line_image,
                         file_id=file_id + '_' + region.id + '_' + line.id + '.IMG-RESEG',
-                        page_id=page_id,
+                        page_id=input_file.pageId,
                         file_grp=self.output_file_grp)
                     # update PAGE (reference the image file):
                     line.add_AlternativeImage(AlternativeImageType(

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -227,6 +227,7 @@ class OcropyResegment(Processor):
                         # crop region arrays accordingly:
                         line_polygon = coordinates_of_segment(line, region_image, region_xywh)
                         line_bbox = bbox_from_polygon(line_polygon)
+                        line_bbox = np.clip(line_bbox, [0] * 4, [region_image.width, region_image.height] * 2)
                         line_labels = region_labels[line_bbox[1]:line_bbox[3],
                                                     line_bbox[0]:line_bbox[2]]
                         line_bin = region_bin[line_bbox[1]:line_bbox[3],

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -334,9 +334,13 @@ class OcropyResegment(Processor):
 def join_polygons(polygons, contract=2):
     # construct convex hull
     jointp = unary_union(polygons).convex_hull
-    # make hull slightly concave by dilation and reconstruction
     # FIXME: calculate true alpha shape
-    jointp = jointp.buffer(-contract)
+    # make hull slightly concave by dilation and reconstruction
+    for step in range(int(contract)+1):
+        nextp = jointp.buffer(-1)
+        if nextp.type == 'MultiPolygon':
+            break
+        jointp = nextp
     jointp = unary_union(polygons + [jointp])
     if jointp.minimum_clearance < 1.0:
         # follow-up calculations will necessarily be integer;

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -333,15 +333,17 @@ class OcropyResegment(Processor):
 
 def join_polygons(polygons, contract=2):
     # construct convex hull
-    jointp = unary_union(polygons).convex_hull
+    compoundp = unary_union(polygons)
+    jointp = compoundp.convex_hull
     # FIXME: calculate true alpha shape
     # make hull slightly concave by dilation and reconstruction
     for step in range(int(contract)+1):
         nextp = jointp.buffer(-1)
-        if nextp.type == 'MultiPolygon':
+        if (nextp.type == 'MultiPolygon' or
+            nextp.union(compoundp).type == 'MultiPolygon'):
             break
         jointp = nextp
-    jointp = unary_union(polygons + [jointp])
+    jointp = jointp.union(compoundp)
     if jointp.minimum_clearance < 1.0:
         # follow-up calculations will necessarily be integer;
         # so anticipate rounding here and then ensure validity

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -52,7 +52,7 @@ class OcropyResegment(Processor):
         self.ocrd_tool = get_ocrd_tool()
         kwargs['ocrd_tool'] = self.ocrd_tool['tools'][TOOL]
         kwargs['version'] = self.ocrd_tool['version']
-        super(OcropyResegment, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def process(self):
         """Resegment lines of the workspace.
@@ -118,7 +118,7 @@ class OcropyResegment(Processor):
             self.add_metadata(pcgts)
             page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID
             page = pcgts.get_Page()
-            
+
             page_image, page_coords, page_image_info = self.workspace.image_from_page(
                 page, page_id, feature_selector='binarized')
             if self.parameter['dpi'] > 0:
@@ -266,9 +266,9 @@ class OcropyResegment(Processor):
                         continue
                     line_polygon = baseline_of_segment(line, parent_coords)
                     line_ltr = line_polygon[0,0] < line_polygon[-1,0]
-                    line_polygon = make_valid(LineString(line_polygon).buffer(
+                    line_polygon = make_valid(join_polygons(LineString(line_polygon).buffer(
                         # left-hand side if left-to-right, and vice versa
-                        scale * (-1) ** line_ltr, single_sided=True))
+                        scale * (-1) ** line_ltr, single_sided=True), loc=line.id))
                     line_polygon = np.array(line_polygon.exterior, np.int)[:-1]
                     line_y, line_x = draw.polygon(line_polygon[:, 1],
                                                   line_polygon[:, 0],

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -249,7 +249,7 @@ class OcropyResegment(Processor):
                         # convert back to absolute (page) coordinates:
                         line_polygon = coordinates_for_segment(line_polygon, region_image, region_xywh)
                     # annotate result:
-                    line.get_Coords().points = points_from_polygon(line_polygon)
+                    line.get_Coords().set_points(points_from_polygon(line_polygon))
                     # create new image:
                     line_image, line_xywh = self.workspace.image_from_segment(
                         line, region_image, region_xywh, feature_selector='binarized')

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -214,7 +214,7 @@ class OcropyResegment(Processor):
                                         parent_bin.shape)] = True
             new_line_labels, _, _, _, _, scale = compute_segmentation(
                 parent_bin, seps=ignore_bin, zoom=zoom, fullpage=fullpage,
-                maxseps=0, maxcolseps=0, maximages=0)
+                maxseps=0, maxcolseps=len(ignore), maximages=0)
         except Exception as err:
             LOG.warning('Cannot line-segment %s "%s": %s',
                         tag, page_id if fullpage else parent.id, err)

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -127,7 +127,7 @@ class OcropyResegment(Processor):
                       page.get_SeparatorRegion() +
                       page.get_UnknownRegion() +
                       page.get_CustomRegion())
-            regions = page.get_AllRegions(classes=['Text'])
+            regions = page.get_AllRegions(classes=['Text'], order='reading-order')
             if not regions:
                 LOG.warning('Page "%s" contains no text regions', page_id)
             elif level == 'page':

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -515,7 +515,7 @@ class OcropySegment(Processor):
             except Exception as err:
                 LOG.error('Cannot region-segment %s "%s": %s',
                             element_name, element_id, err)
-                region_labels = np.array(line_labels > 0, np.uint8)
+                region_labels = np.where(line_labels > len(ignore), 1 + len(ignore), line_labels)
             
             # prepare reading order group index
             if rogroup:

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -366,6 +366,10 @@ class OcropySegment(Processor):
                     # TODO: also allow grayscale_normalized (try/except?)
                     region_image, region_coords = self.workspace.image_from_segment(
                         region, page_image, page_coords, feature_selector='binarized')
+                    # if the region images have already been clipped against their neighbours specifically,
+                    # then we don't need to suppress all neighbours' foreground generally here
+                    if 'clipped' in region_coords['features'].split(','):
+                        ignore = []
                     # go get TextLines
                     self._process_element(region, ignore, region_image, region_coords,
                                           region.id, file_id + '_' + region.id,
@@ -450,7 +454,7 @@ class OcropySegment(Processor):
                 raise Exception(report)
             line_labels, hlines, vlines, images, colseps, scale = compute_segmentation(
                 # suppress separators and ignored regions for textline estimation
-                # but keep them for h/v-line detection:
+                # but keep them for h/v-line detection (in fullpage mode):
                 element_bin, seps=(sep_bin+ignore_labels)>0,
                 zoom=zoom, fullpage=fullpage,
                 spread_dist=round(self.parameter['spread']/zoom*300/72), # in pt

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -560,7 +560,7 @@ class OcropySegment(Processor):
                 order[np.setdiff1d(region_line_labels0, element_bin * region_line_labels)] = 0
                 region_line_labels = order[region_line_labels]
                 # avoid horizontal gaps
-                region_line_labels = hmerge_line_seeds(element_bin, region_line_labels, scale)
+                region_line_labels = hmerge_line_seeds(element_bin, region_line_labels, scale, seps=sepmask)
                 # find contours for region (can be non-contiguous)
                 regions, _ = masks2polygons(region_mask * region_label, element_bin,
                                             '%s "%s"' % (element_name, element_id),

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -424,6 +424,9 @@ class OcropySegment(Processor):
         newly detected separators to guide region segmentation.
         """
         LOG = getLogger('processor.OcropySegment')
+        if not image.width or not image.height:
+            LOG.warning("Skipping '%s' with zero size", element_id)
+            return
         element_array = pil2array(image)
         element_bin = np.array(element_array <= midrange(element_array), np.bool)
         sep_bin = np.zeros_like(element_bin, np.bool)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -544,6 +544,7 @@ class OcropySegment(Processor):
                 if not np.all(region_line_labels0 > len(ignore)):
                     # existing region from `ignore` merely to be ordered
                     # (no new region, no actual text lines)
+                    region_line_labels0 = np.intersect1d(region_line_labels0, ignore_labels)
                     assert len(region_line_labels0) == 1, \
                         "region label %d has both existing regions and new lines (%s)" % (
                             region_label, str(region_line_labels0))

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -720,7 +720,7 @@ def polygon_for_parent(polygon, parent):
     parentp = make_valid(parentp)
     # check if clipping is necessary
     if childp.within(parentp):
-        return polygon
+        return childp.exterior.coords[:-1]
     # clip to parent
     interp = childp.intersection(parentp)
     # post-process

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -521,7 +521,7 @@ class OcropySegment(Processor):
                          element_name, element_id)
             except Exception as err:
                 LOG.error('Cannot region-segment %s "%s": %s',
-                            element_name, element_id, err)
+                          element_name, element_id, err)
                 region_labels = np.where(line_labels > len(ignore), 1 + len(ignore), line_labels)
             
             # prepare reading order group index
@@ -563,7 +563,9 @@ class OcropySegment(Processor):
                 order[np.setdiff1d(region_line_labels0, element_bin * region_line_labels)] = 0
                 region_line_labels = order[region_line_labels]
                 # avoid horizontal gaps
-                region_line_labels = hmerge_line_seeds(element_bin, region_line_labels, scale, seps=sepmask)
+                region_line_labels = hmerge_line_seeds(element_bin, region_line_labels, scale,
+                                                       seps=np.maximum(sepmask, colseps))
+                region_mask |= region_line_labels > 0
                 # find contours for region (can be non-contiguous)
                 regions, _ = masks2polygons(region_mask * region_label, element_bin,
                                             '%s "%s"' % (element_name, element_id),

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -727,7 +727,11 @@ def polygon_for_parent(polygon, parent):
     if childp.within(parentp):
         return childp.exterior.coords[:-1]
     # clip to parent
-    interp = childp.intersection(parentp)
+    interp = make_intersection(childp, parentp)
+    return interp.exterior.coords[:-1] # keep open
+
+def make_intersection(poly1, poly2):
+    interp = poly1.intersection(poly2)
     # post-process
     if interp.is_empty or interp.area == 0.0:
         return None
@@ -743,7 +747,7 @@ def polygon_for_parent(polygon, parent):
         # so anticipate rounding here and then ensure validity
         interp = asPolygon(np.round(interp.exterior.coords))
         interp = make_valid(interp)
-    return interp.exterior.coords[:-1] # keep open
+    return interp
 
 def make_valid(polygon):
     for split in range(1, len(polygon.exterior.coords)-1):

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -731,11 +731,17 @@ def polygon_for_parent(polygon, parent):
     # (this can happen when shapes valid in floating point are rounded)
     childp = make_valid(childp)
     parentp = make_valid(parentp)
+    if not childp.is_valid:
+        return None
+    if not parentp.is_valid:
+        return None
     # check if clipping is necessary
     if childp.within(parentp):
         return childp.exterior.coords[:-1]
     # clip to parent
     interp = make_intersection(childp, parentp)
+    if not interp:
+        return None
     return interp.exterior.coords[:-1] # keep open
 
 def make_intersection(poly1, poly2):

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -714,13 +714,13 @@ def polygon_for_parent(polygon, parent):
                                [parent.get_imageWidth(),0]])
     else:
         parentp = Polygon(polygon_from_points(parent.get_Coords().points))
-    # check if clipping is necessary
-    if childp.within(parentp):
-        return polygon
     # ensure input coords have valid paths (without self-intersection)
     # (this can happen when shapes valid in floating point are rounded)
     childp = make_valid(childp)
     parentp = make_valid(parentp)
+    # check if clipping is necessary
+    if childp.within(parentp):
+        return polygon
     # clip to parent
     interp = childp.intersection(parentp)
     # post-process

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -552,7 +552,7 @@ class OcropySegment(Processor):
                         "region label %d has both existing regions and new lines (%s)" % (
                             region_label, str(region_line_labels0))
                     region = ignore[region_line_labels0[0] - 1]
-                    if rogroup and not isinstance(region, SeparatorRegionType):
+                    if rogroup and region.parent_object_ == element and not isinstance(region, SeparatorRegionType):
                         index = page_add_to_reading_order(rogroup, region.id, index)
                     LOG.debug('Region label %d is for ignored region "%s"',
                               region_label, region.id)

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -472,7 +472,7 @@ class OcropySegment(Processor):
                 hlminwidth=self.parameter['hlminwidth'])
         except Exception as err:
             if isinstance(element, TextRegionType):
-                LOG.warning('Cannot line-segment region "%s": %s', element_id, err)
+                LOG.error('Cannot line-segment region "%s": %s', element_id, err)
                 # as a fallback, add a single text line comprising the whole region:
                 element.add_TextLine(TextLineType(id=element_id + "_line", Coords=element.get_Coords()))
             else:
@@ -507,7 +507,7 @@ class OcropySegment(Processor):
                          len(np.unique(region_labels)) - 1,
                          element_name, element_id)
             except Exception as err:
-                LOG.warning('Cannot region-segment %s "%s": %s',
+                LOG.error('Cannot region-segment %s "%s": %s',
                             element_name, element_id, err)
                 region_labels = np.array(line_labels > 0, np.uint8)
             

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -850,6 +850,7 @@ def page_subgroup_in_reading_order(roelem):
         roelem2 = OrderedGroupType(id=roelem.regionRef + '_group',
                                    regionRef=roelem.regionRef)
         roelem.parent_object_.add_OrderedGroup(roelem2)
+        roelem2.parent_object_ = roelem.parent_object_
         return roelem2
     if isinstance(roelem, (OrderedGroupIndexedType,
                            UnorderedGroupIndexedType,
@@ -863,5 +864,6 @@ def page_subgroup_in_reading_order(roelem):
                                           index=roelem.index,
                                           regionRef=roelem.regionRef)
         roelem.parent_object_.add_OrderedGroupIndexed(roelem2)
+        roelem2.parent_object_ = roelem.parent_object_
         return roelem2
     return None

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -855,8 +855,8 @@ def page_subgroup_in_reading_order(roelem):
                            UnorderedGroupIndexedType,
                            RegionRefIndexedType)):
         getattr(roelem.parent_object_, {
-            OrderedGroupIndexedType: 'get_OrderedIndexedGroup',
-            UnorderedGroupIndexedType: 'get_UnorderedIndexedGroup',
+            OrderedGroupIndexedType: 'get_OrderedGroupIndexed',
+            UnorderedGroupIndexedType: 'get_UnorderedGroupIndexed',
             RegionRefIndexedType: 'get_RegionRefIndexed'
         }.get(roelem.__class__))().remove(roelem)
         roelem2 = OrderedGroupIndexedType(id=roelem.regionRef + '_group',

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -295,6 +295,11 @@ class OcropySegment(Processor):
                 self._process_element(page, ignore, page_image, page_coords,
                                       page_id, file_id,
                                       input_file.pageId, zoom, rogroup=rogroup)
+                if (not rogroup.get_RegionRefIndexed() and
+                    not rogroup.get_OrderedGroupIndexed() and
+                    not rogroup.get_UnorderedGroupIndexed()):
+                     # schema forbids empty OrderedGroup
+                    ro.set_OrderedGroup(None)
             elif oplevel == 'table':
                 ignore.extend(page.get_TextRegion())
                 regions = list(page.get_TableRegion())

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -344,7 +344,7 @@ class OcropySegment(Processor):
                     # go get TextRegions with TextLines (and SeparatorRegions)
                     self._process_element(region, subignore, region_image, region_coords,
                                           region.id, file_id + '_' + region.id,
-                                          input_file.pageid, zoom, rogroup=roelem)
+                                          input_file.pageId, zoom, rogroup=roelem)
             else: # 'region'
                 regions = list(page.get_TextRegion())
                 # besides top-level text regions, line-segment any table cells,

--- a/ocrd_cis/ocropy/segment.py
+++ b/ocrd_cis/ocropy/segment.py
@@ -619,7 +619,7 @@ class OcropySegment(Processor):
             image_clipped = array2pil(element_array)
             file_path = self.workspace.save_image_file(
                 image_clipped, file_id + '.IMG-CLIP',
-                pageId=page_id,
+                page_id=page_id,
                 file_grp=self.output_file_grp)
             element.add_AlternativeImage(AlternativeImageType(
                 filename=file_path, comments=coords['features'] + ',clipped'))
@@ -646,7 +646,18 @@ class OcropySegment(Processor):
                 # annotate result:
                 element.add_TextLine(TextLineType(id=line_id, Coords=CoordsType(
                     points=points_from_polygon(line_polygon))))
-
+            if not sep_bin.any():
+                return
+            # annotate a text/image-separated image
+            element_array[sep_bin] = np.amax(element_array) # clip to white/bg
+            image_clipped = array2pil(element_array)
+            file_path = self.workspace.save_image_file(
+                image_clipped, file_id + '.IMG-CLIP',
+                page_id=page_id,
+                file_grp=self.output_file_grp)
+            # update PAGE (reference the image file):
+            element.add_AlternativeImage(AlternativeImageType(
+                filename=file_path, comments=coords['features'] + ',clipped'))
 
 def polygon_for_parent(polygon, parent):
     """Clip polygon to parent polygon range.

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,14 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'ocrd>=2.13',
+        'ocrd>=2.30',
         'click',
         'scipy',
         'numpy>=1.17.0',
         'pillow>=7.1.2',
-        'shapely>=1.7.1',
+        'shapely>=1.7.1,<1.8',
         'scikit-image',
+        'alphashape',
         'opencv-python-headless',
         'python-Levenshtein',
         'calamari_ocr == 0.3.5'


### PR DESCRIPTION
Fixes a bug when the input lines are already empty.

I'll shortly append more fixes in the follow-up: 

For example, I found that `resegment` does not cope well with large overlaps. The current algorithm simply fetches the largest line (optimising locally), without checking the neighbouring choices (optimising globally). See:
- input: ![resegment-in](https://user-images.githubusercontent.com/38561704/97480447-b4b9fd80-1953-11eb-98fc-63564a976f0a.png)
- output: ![resegment-out](https://user-images.githubusercontent.com/38561704/97480464-bbe10b80-1953-11eb-9bc3-e3f924c10cc6.png)

